### PR TITLE
qa-chars-vs-markup de/pl, qa-site-conneg en/sv minor corrections

### DIFF
--- a/questions/qa-chars-vs-markup.de.html
+++ b/questions/qa-chars-vs-markup.de.html
@@ -221,14 +221,14 @@ f.additionalLinks = ''
     </li>
     <li>
       <p>Verwandte Links, <cite>HTML und CSS erstellen</cite></p>
-      <ul><li><a href="/International/techniques/authoring-html#charset">Characters</a></li>
-      <li><a href="/International/techniques/authoring-html#controlcodes">Using Unicode control codes in text</a></li>
+      <ul><li><a href="/International/techniques/authoring-html#charset">Zeichen</a></li>
+      <li><a href="/International/techniques/authoring-html#controlcodes">Verwendung von Unicode-Steuerzeichen in Text</a></li>
       </ul>
     </li>
     <li>
       <p>Verwandte Links, <cite>XML erstellen</cite></p>
-      <ul><li><a href="/International/techniques/authoring-xml#charset">Characters</a></li>
-      <li><a href="/International/techniques/authoring-html#controls">Using Unicode control codes in text</a></li>
+      <ul><li><a href="/International/techniques/authoring-xml#charset">Zeichen</a></li>
+      <li><a href="/International/techniques/authoring-html#controls">Verwendung von Unicode-Steuerzeichen in Text</a></li>
       </ul>
     </li>
   </ul>

--- a/questions/qa-chars-vs-markup.de.html
+++ b/questions/qa-chars-vs-markup.de.html
@@ -220,13 +220,13 @@ f.additionalLinks = ''
       <p>Tutorial: <a href="/International/tutorials/tutorial-char-enc/"><cite>Umgang mit Zeichencodierungen in HTML und CSS</cite></a> <span class="uri">http://www.w3.org/International/tutorials/tutorial-char-enc/</span></p>
     </li>
     <li>
-      <p>Verwandte Links, <cite>HTML und CSS erstellen</cite></p>
+      <p>Verwandte Links: <cite>HTML und CSS erstellen</cite></p>
       <ul><li><a href="/International/techniques/authoring-html#charset">Zeichen</a></li>
       <li><a href="/International/techniques/authoring-html#controlcodes">Verwendung von Unicode-Steuerzeichen in Text</a></li>
       </ul>
     </li>
     <li>
-      <p>Verwandte Links, <cite>XML erstellen</cite></p>
+      <p>Verwandte Links: <cite>XML erstellen</cite></p>
       <ul><li><a href="/International/techniques/authoring-xml#charset">Zeichen</a></li>
       <li><a href="/International/techniques/authoring-html#controls">Verwendung von Unicode-Steuerzeichen in Text</a></li>
       </ul>

--- a/questions/qa-chars-vs-markup.de.html
+++ b/questions/qa-chars-vs-markup.de.html
@@ -20,7 +20,7 @@ f.status = 'published'  // should be one of draft, review, published, notreviewe
 f.path = '../' // what you need to prepend to a URL to get to the /International directory 
 
 // AUTHORS AND TRANSLATORS should fill in these assignments:
-f.thisVersion = { date:'2016-02-97', time:'10:10'} // date and time of latest edits to this document/translation
+f.thisVersion = { date:'2015-08-12', time:'15:00'} // date and time of latest edits to this document/translation
 f.contributors = '' // people providing useful contributions or feedback during review or at other times
 // also make sure that the lang attribute on the html tag is correct!
 f.sources = '' // describes sources of information

--- a/questions/qa-chars-vs-markup.pl.html
+++ b/questions/qa-chars-vs-markup.pl.html
@@ -58,7 +58,7 @@ f.additionalLinks = ''
     </div>
     
   <h2 id="question"><a href="#question">Question</a></h2>
-    <p class="question">Istnieją takie znaki sterujące Unicode, które spełniają tą samą rolę jak znaczniki. Które należy stosować, a których należy unikać?</p>
+    <p class="question">Istnieją takie znaki sterujące Unicode, które spełniają tę samą rolę jak znaczniki. Które należy stosować, a których należy unikać?</p>
 </section>
 
 

--- a/questions/qa-chars-vs-markup.pl.html
+++ b/questions/qa-chars-vs-markup.pl.html
@@ -163,7 +163,7 @@ f.additionalLinks = ''
   </section>
 
   <section>
-    <h3 id="compat"><a href="#compat">'Znaki kompatybilności różnią się w ich stosowalności</a></h3>
+    <h3 id="compat"><a href="#compat">Znaki kompatybilności różnią się w ich stosowalności</a></h3>
     <p>Wyciąg z <a class="print" href="http://www.w3.org/TR/unicode-xml/"><cite lang="en">Unicode in XML &amp; Other Markup Languages</cite></a>:</p>
     <blockquote>
       <p>Standard Unicode podaje mapę kompatybilności dla niektórych znaków. Mapy kompatybilności wskazują relację do innego znaku, ale dokładny charakter tego stosunku różni się. W niektórych przypadkach ten stosunek oznacza „bazuje na”, w innych przypadkach określa właściwość. Kiedy tekst zostaje oznaczony znacznikami, może mieć sens zmapowanie niektórych z tych znaków z ich kompatybilnymi odpowiednikami i odpowiednymi znacznikami. Ważnym jest rozumieć naturę różnic pomiędzy znakami i ich kompatybilnymi odpowiednikami oraz kontekst, w którym te różnice się liczą. Nie zaleca się stosować map kompatybilności bezkrytycznie.</p>

--- a/questions/qa-chars-vs-markup.pl.html
+++ b/questions/qa-chars-vs-markup.pl.html
@@ -220,14 +220,14 @@ f.additionalLinks = ''
     </li>
     <li>
       <p>Powiązane artykuły: <cite>Tworzenie dokumentów HTML i CSS</cite></p>
-      <ul><li><a href="/International/techniques/authoring-html#charset">Characters</a></li>
-      <li><a href="/International/techniques/authoring-html#controlcodes">Using Unicode control codes in text</a></li>
+      <ul><li><a href="/International/techniques/authoring-html#charset">Znaki</a></li>
+      <li><a href="/International/techniques/authoring-html#controlcodes">Stosować znaki sterujące Unicode w tekscie</a></li>
       </ul>
     </li>
     <li>
       <p>Powiązane artykuły: <cite>Tworzenie dokumentów XML</cite></p>
-      <ul><li><a href="/International/techniques/authoring-xml#charset">Characters</a></li>
-      <li><a href="/International/techniques/authoring-html#controls">Using Unicode control codes in text</a></li>
+      <ul><li><a href="/International/techniques/authoring-xml#charset">Znaki</a></li>
+      <li><a href="/International/techniques/authoring-html#controls">Stosować znaki sterujące Unicode w tekscie</a></li>
       </ul>
     </li>
   </ul>

--- a/questions/qa-chars-vs-markup.pl.html
+++ b/questions/qa-chars-vs-markup.pl.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <title>Znaki czy znaczniki?</title>
-<meta name="description" content="Istnieją takie znaki sterujące Unicode, które spełniają tą samą rolę jak znaczniki. Które należy stosować, a których należy unikać?" />
+<meta name="description" content="Istnieją takie znaki sterujące Unicode, które spełniają tę samą rolę jak znaczniki. Które należy stosować, a których należy unikać?" />
 <script type="text/javascript">
 var f = { }
 

--- a/questions/qa-chars-vs-markup.pl.html
+++ b/questions/qa-chars-vs-markup.pl.html
@@ -20,7 +20,7 @@ f.status = 'published'  // should be one of draft, review, published, notreviewe
 f.path = '../' // what you need to prepend to a URL to get to the /International directory 
 
 // AUTHORS AND TRANSLATORS should fill in these assignments:
-f.thisVersion = { date:'2016-02-97', time:'10:10'} // date and time of latest edits to this document/translation
+f.thisVersion = { date:'2015-08-12', time:'15:00'} // date and time of latest edits to this document/translation
 f.contributors = '' // people providing useful contributions or feedback during review or at other times
 // also make sure that the lang attribute on the html tag is correct!
 f.sources = '' // describes sources of information

--- a/questions/qa-site-conneg.en.html
+++ b/questions/qa-site-conneg.en.html
@@ -21,7 +21,7 @@ f.path = '../' // what you need to prepend to a URL to get to the /International
 
 // AUTHORS AND TRANSLATORS should fill in these assignments:
 f.thisVersion = { date:'2016-03-11', time:'10:49'} // date and time of latest edits to this document/translation
-f.contributors = 'Olle Olsson, Gunnar Bittersman'; // people providing useful contributions or feedback during review or at other times
+f.contributors = 'Olle Olsson, Gunnar Bittersmann'; // people providing useful contributions or feedback during review or at other times
 // also make sure that the lang attribute on the html tag is correct!
 
 // TRANSLATORS should fill in these assignments:

--- a/questions/qa-site-conneg.sv.html
+++ b/questions/qa-site-conneg.sv.html
@@ -21,7 +21,7 @@ f.path = '../' // what you need to prepend to a URL to get to the /International
 
 // AUTHORS AND TRANSLATORS should fill in these assignments:
 f.thisVersion = { date:'2016-03-11', time:'10:49'} // date and time of latest edits to this document/translation
-f.contributors = 'Olle Olsson, Gunnar Bittersman'; // people providing useful contributions or feedback during review or at other times
+f.contributors = 'Olle Olsson, Gunnar Bittersmann'; // people providing useful contributions or feedback during review or at other times
 // also make sure that the lang attribute on the html tag is correct!
 
 // TRANSLATORS should fill in these assignments:


### PR DESCRIPTION
This corrects the spelling of my name in qa-site-conneg and a grammatical error and thisVersion time in qa-chars-vs-markup, and adds translations of recently added further reading
