### PR TITLE
Translation contributor credits

### DIFF
--- a/articles/serving-xhtml/index.de.html
+++ b/articles/serving-xhtml/index.de.html
@@ -26,7 +26,8 @@ f.contributors = '' // people providing useful contributions or feedback during 
 f.sources = '' // describes sources of information
 
 // TRANSLATORS should fill in these assignments:
-f.translators = '<a href="http://bittersmann.de/">Gunnar Bittersmann</a> mit <a href="http://julianewuensche.de/">Juliane Wünsche</a>' // translator(s) and their affiliation - a elements allowed, but use double quotes for attributes
+f.translators = '<a href="http://bittersmann.de/">Gunnar Bittersmann</a>' // translator(s) and their affiliation - a elements allowed, but use double quotes for attributes
+f.translationContributors = 'Juliane Wünsche' // people providing useful contributions or feedback to this translation
 
 f.breadcrumb = 'other'
 

--- a/javascript/boilerplate-text/boilerplate-de.js
+++ b/javascript/boilerplate-text/boilerplate-de.js
@@ -131,5 +131,5 @@ s.quickanswer = "Kurze Antwort" // heading
 s.longeranswer = "Details" // heading
 s.additionalinfo = "Weitere Informationen" // heading that sometimes follows 'Details'
 s.acknowledgements = "Vielen Dank für die Beiträge und Kommentare zu diesem Artikel an:" // used at bottom of page to list people who provided feedback. The list comes after this text. 
-s.translationAcknowledgements = "Thanks also to the following people whose contribution or feedback was included in this translation:" // used at bottom of page to list people who provided feedback to the translation. The list comes after this text. 
+s.translationAcknowledgements = "Vielen Dank für die Beiträge und Kommentare zu dieser Übersetzung an:" // used at bottom of page to list people who provided feedback to the translation. The list comes after this text. 
 s.cookieMsg = "If you let the browser set a cookie, you will continue to see W3C Internationalization Activity pages (where available) in the language you chose. Do you want to set the cookie?" // this text is to be copied to another location

--- a/javascript/boilerplate-text/boilerplate-de.js
+++ b/javascript/boilerplate-text/boilerplate-de.js
@@ -131,4 +131,5 @@ s.quickanswer = "Kurze Antwort" // heading
 s.longeranswer = "Details" // heading
 s.additionalinfo = "Weitere Informationen" // heading that sometimes follows 'Details'
 s.acknowledgements = "Vielen Dank für die Beiträge und Kommentare zu diesem Artikel an:" // used at bottom of page to list people who provided feedback. The list comes after this text. 
+s.translationAcknowledgements = "Thanks also to the following people whose contribution or feedback was included in this translation:" // used at bottom of page to list people who provided feedback to the translation. The list comes after this text. 
 s.cookieMsg = "If you let the browser set a cookie, you will continue to see W3C Internationalization Activity pages (where available) in the language you chose. Do you want to set the cookie?" // this text is to be copied to another location

--- a/javascript/boilerplate-text/boilerplate-en.js
+++ b/javascript/boilerplate-text/boilerplate-en.js
@@ -129,5 +129,6 @@ s.quickanswer = "Quick answer" // heading
 s.longeranswer = "Details" // heading that follows 'Quick answer'
 s.additionalinfo = "Additional information" // heading that sometimes follows 'Details'
 s.acknowledgements = "Thanks also to the following people whose contribution or feedback was included:" // used at bottom of page to list people who provided feedback. The list comes after this text. 
+s.translationAcknowledgements = "Thanks also to the following people whose contribution or feedback was included in this translation:" // used at bottom of page to list people who provided feedback to the translation. The list comes after this text. 
 s.cookieMsg = "If you let the browser set a cookie, you will continue to see W3C Internationalization Activity pages (where available) in the language you chose. Do you want to set the cookie?" // this text is to be copied to another location
 //s.supercededTranslation = '<strong>Avertissement :</strong> Ceci est une version dépassée de ce document! Il est recommandé de lire <a href="'+g.betterfilename+'.en">la dernière version</a> et si vous le pouvez, de modifier le marque-page ou le lien qui vous a redirigé ici.'

--- a/javascript/boilerplate-text/boilerplate-pl.js
+++ b/javascript/boilerplate-text/boilerplate-pl.js
@@ -129,4 +129,5 @@ s.quickanswer = "Quick answer" // heading
 s.longeranswer = "Longer answer" // heading
 s.additionalinfo = "Additional information" // heading that sometimes follows 'Details'
 s.acknowledgements = "Thanks also to the following people whose contribution or feedback was included:" // used at bottom of page to list people who provided feedback. The list comes after this text. 
+s.translationAcknowledgements = "Thanks also to the following people whose contribution or feedback was included in this translation:" // used at bottom of page to list people who provided feedback to the translation. The list comes after this text. 
 s.cookieMsg = "If you let the browser set a cookie, you will continue to see W3C Internationalization Activity pages (where available) in the language you chose. Do you want to set the cookie?" // this text is to be copied to another location

--- a/javascript/doc-structure/article.js
+++ b/javascript/doc-structure/article.js
@@ -204,6 +204,7 @@ if (g.isTranslation) translatorCredit = s.translatedBy+' '+f.translators+s.sente
 
 var credits = "<p>"+s.author+' '+f.authors+s.sentenceDelimiter+' '+previousCredit+modCredit+translatorCredit+"</p>"
 if (f.contributors && f.contributors != '') credits += "<p class='acknowledgements'>"+s.acknowledgements+" "+f.contributors+"</p>"
+if (f.translationContributors && f.translationContributors != '') credits += "<p class='acknowledgements'>"+s.translationAcknowledgements+" "+f.translationContributors+"</p>"
 if (f.sources && f.sources != '') credits += "<p class='acknowledgements'>"+f.sources+"</p>"
 
 

--- a/questions/qa-chars-vs-markup.pl.html
+++ b/questions/qa-chars-vs-markup.pl.html
@@ -26,7 +26,8 @@ f.contributors = '' // people providing useful contributions or feedback during 
 f.sources = '' // describes sources of information
 
 // TRANSLATORS should fill in these assignments:
-f.translators = '<a href="http://bittersmann.de/">Gunnar Bittersmann</a>, korekta: Michał Kreft' // translator(s) and their affiliation - a elements allowed, but use double quotes for attributes
+f.translators = '<a href="http://bittersmann.de/">Gunnar Bittersmann</a>' // translator(s) and their affiliation - a elements allowed, but use double quotes for attributes
+f.translationContributors = 'Michał Kreft' // people providing useful contributions or feedback to this translation
 
 f.breadcrumb = 'characters'
 

--- a/questions/qa-when-lang-neg.de.html
+++ b/questions/qa-when-lang-neg.de.html
@@ -26,7 +26,8 @@ f.contributors = '' // people providing useful contributions or feedback during 
 f.sources = '' // describes sources of information
 
 // TRANSLATORS should fill in these assignments:
-f.translators = '<a href="http://bittersmann.de/">Gunnar Bittersmann</a> mit <a href="http://julianewuensche.de/">Juliane Wünsche</a>' // translator(s) and their affiliation - a elements allowed, but use double quotes for attributes
+f.translators = '<a href="http://bittersmann.de/">Gunnar Bittersmann</a>' // translator(s) and their affiliation - a elements allowed, but use double quotes for attributes
+f.translationContributors = 'Juliane Wünsche' // people providing useful contributions or feedback to this translation
 
 f.breadcrumb = 'navigation'
 


### PR DESCRIPTION
Introducing f.translationContributors as optional field for translators to give credit where credit is due.
Its label is s.translationAcknowledgements which needs to be included in the boilerplates.
(This could be done together with s.acknowledgements which is still missing in some boilerplates.)
