### PR TITLE
Fix broken links

### DIFF
--- a/questions/qa-html-encoding-declarations.de.html
+++ b/questions/qa-html-encoding-declarations.de.html
@@ -173,7 +173,7 @@ f.additionalLinks = ''
   </section>
   <section>
     <h3 id="legacyhtml"><a href="#legacyhtml">Ältere HTML-Formate</a></h3>
-    <p>HTML&nbsp;4.01 spezifiziert kein <code class="kw" translate="no">charset</code>-Attribut für das <code class="kw" translate="no">meta</code>-Element, doch jeder gängige Browser erkennt es und wendet es an, auch wenn die Seite als HTML4 und nicht als HTML5 deklariert ist. Dieser Abschnitt ist nur relevant, wenn Sie aus anderen Gründen als die Auslieferung an Browser an eine ältere HTML-Version gebunden sind. Er beschreibt Abweichungen vom Abschnitt Antwort weiter oben.</p>
+    <p>HTML&nbsp;4.01 spezifiziert kein <code class="kw" translate="no">charset</code>-Attribut für das <code class="kw" translate="no">meta</code>-Element, doch jeder gängige Browser erkennt es und wendet es an, auch wenn die Seite als HTML4 und nicht als HTML5 deklariert ist. Dieser Abschnitt ist nur relevant, wenn Sie aus anderen Gründen als die Auslieferung an Browser an eine ältere HTML-Version gebunden sind. Er beschreibt Abweichungen vom Abschnitt <a href="#quickanswer">Kurze Antwort</a> weiter oben.</p>
     <p>Für Seiten, die als XML ausgeliefert werden, siehe <a href="#xml">Polyglottes HTML und XML-Formate</a>.</p>
     <p><b class="leadin">HTML4:</b> Wie eben gesagt, müssen Sie die Pragma-Direktive statt des <code class="kw" translate="no">charset</code>-Attributs verwenden, um konform mit HTML&nbsp;4.01 zu sein.</p>
     <p><b class="leadin">XHTML 1.x ausgeliefert text/html:</b> Auch hier müssen Sie die Pragma-Direktive statt des <code class="kw" translate="no">charset</code>-Attributs verwenden, um konform mit HTML&nbsp;4.01 zu sein. Sie müssen keine XML-Deklaration verwenden, denn die Datei wird als HTML verarbeitet.</p>

--- a/questions/qa-html-encoding-declarations.en.html
+++ b/questions/qa-html-encoding-declarations.en.html
@@ -184,7 +184,7 @@ f.additionalLinks = ''
   
   <section>
     <h3 id="legacyhtml"><a href="#legacyhtml">Working with legacy HTML formats</a></h3>
-    <p>HTML&nbsp;4.01 doesn't specify the use of the <code class="kw" translate="no">charset</code> attribute with the <code class="kw" translate="no">meta</code> element, but any recent major browser will still detect it and use it, even if the page is declared to be HTML4 rather than HTML5. This section is only relevant if you have some other reason than serving to a browser for conforming to an older format of HTML. It describes any differences from the <a href="#answer">Answer</a> section above.</p>
+    <p>HTML&nbsp;4.01 doesn't specify the use of the <code class="kw" translate="no">charset</code> attribute with the <code class="kw" translate="no">meta</code> element, but any recent major browser will still detect it and use it, even if the page is declared to be HTML4 rather than HTML5. This section is only relevant if you have some other reason than serving to a browser for conforming to an older format of HTML. It describes any differences from the <a href="#quickanswer">Quick answer</a> section above.</p>
     <p>For pages served as XML, see <a href="#xml">Working with polyglot and XML formats</a>.</p>
     <p><b class="leadin">HTML4:</b> As mentioned just above, you need to use the pragma directive for full conformance with HTML&nbsp;4.01, rather than the <code class="kw" translate="no">charset</code> attribute.</p>
     <p><b class="leadin">XHTML 1.x served as text/html:</b> Also needs the pragma directive for full conformance with HTML&nbsp;4.01, rather than the <code class="kw" translate="no">charset</code> attribute. You do not need to use the XML declaration, since the file is being served as HTML.</p>

--- a/questions/qa-html-encoding-declarations.sv.html
+++ b/questions/qa-html-encoding-declarations.sv.html
@@ -293,7 +293,7 @@ f.additionalLinks = ''
       använda det, även om sidan anges vara i HTML4 och inte i HTML5.
       Denna sektion är bara relevant om du använder äldre
       HTML-format av andra skäl än att leverera till en webbläsare.
-      Här beskrivs skillnaderna gentemot vad som sagts i sektionen <a href="#answer">Svar</a> ovan. </p>
+      Här beskrivs skillnaderna gentemot vad som sagts i sektionen <a href="#quickanswer">Snabbt svar</a> ovan. </p>
     <p> För sidor som levereras som XML, läs då <a href="#xml">Att arbeta med polyglott format och XML-format</a>. </p>
     <p> <b class="leadin">HTML4:</b> Som nämnts ovan så behöver du
       används pragma-direktivet för att följa standarden 


### PR DESCRIPTION
The link that references `#answer` in “Declaring character encodings in
HTML” is broken. This should reference `#quickanswer`.
