### PR TITLE
the-q-element: editorial

### DIFF
--- a/questions/qa-the-q-element.en.html
+++ b/questions/qa-the-q-element.en.html
@@ -17,7 +17,7 @@ f.searchString = 'qa-the-q-element'; // blog search string - usually the filenam
 f.firstPubDate = '2018-04-18'; // date of the first publication of the document (after review)
 f.lastSubstUpdate = { date:'2018-04-18', time:'17:03'}  // date and time of latest substantive changes to this document
 f.status = 'draft';  // should be one of draft, review, published, notreviewed or obsolete
-f.path = '../' // what you need to prepend to a URL to get to the /International directory 
+f.path = '../' // what you need to prepend to a URL to get to the /International directory
 
 // AUTHORS AND TRANSLATORS should fill in these assignments:
 f.thisVersion = { date:'2018-04-18', time:'17:03'} // date and time of latest edits to this document/translation
@@ -49,7 +49,7 @@ f.additionalLinks = ''
 
 
 <body>
-<header> 
+<header>
   <nav id="mainNavigation"></nav><script>document.getElementById('mainNavigation').innerHTML = mainNavigation</script>
 
   <h1>Using the <span class="kw" translate="no">q</span> element<br>
@@ -59,7 +59,7 @@ f.additionalLinks = ''
 
 <section>
   <div id="audience">
-    <p><span id="intendedAudience" class="leadin">Intended audience:</span> 
+    <p><span id="intendedAudience" class="leadin">Intended audience:</span>
     HTML coders (using editors or scripting), script developers (PHP, JSP, etc.), CSS coders, Web project managers, and anyone who is new to character encodings and needs an introduction to how to choose and apply character encodings.</p>
     <div id="updateInfo"></div><script>document.getElementById('updateInfo').innerHTML = g.updated</script>
     </div>
@@ -75,14 +75,14 @@ f.additionalLinks = ''
 
 <section id="nutshell">
 <h2 id="quickanswer"><a href="#quickanswer">Quick answer</a></h2>
-  
+
     <p>TBD</p>
 </section>
 
 
 <section>
   <h2 id="how"><a href="#how">How quotation marks are used</a></h2>
-  
+
     <p>Let’s begin by examining some use cases and establishing some ground rules, using an example to illustrate what most people would expect to see when using quotation marks. </p>
     <p>Take the following sentence. (Whether or not the final period belongs inside or outside the quotation marks depends on your preference. We’ll omit it to keep the example simple.)</p>
     <div class="example">
@@ -121,7 +121,7 @@ f.additionalLinks = ''
 
 <section>
 <h3 id="monolingual_defaults"><a href="#monolingual_defaults">Monolingual pages</a></h3>
-    <p>Let's assume you have the following markup, in a page where the language of the  <code class="kw" translate="no">html</code> tag is set to Swiss French using <code>lang=&quot;fr-CH</code>.</p>
+    <p>Let's assume you have the following markup, in a page where the language of the  <code class="kw" translate="no">html</code> tag is set to Swiss French using <code>lang=&quot;fr-CH&quot;</code>.</p>
 <div class="example">
 <p lang="fr">Mais Lucy répondit: &lt;q&gt;Embrassez George de ma part et dites-lui, &lt;q&gt;Embrouille&lt;/q&gt;&lt;/q&gt;</p>
 </div>
@@ -132,7 +132,7 @@ f.additionalLinks = ''
 <p>For browsers that do generate quotation marks per the language of the text, the quotation marks used follow the settings recommended by the CLDR repository. This is specified in the HTML standard.</p>
 <p>However, support varies by language, and doesn't cover all languages. There may not be a default set for the particular language you are using.</p>
 </section>
-  
+
   <section>
     <h3 id="multilingual_defaults"><a href="#multilingual_defaults">Multilingual text</a></h3>
     <p>But what if the quotation is in a different language than the surrounding text? This is where we begin to run into difficulties.</p>
@@ -152,7 +152,7 @@ f.additionalLinks = ''
 <p>The W3C version of HTML currently specifies that the version of the quotation marks should be set according to the language indicated on the <code class="kw" translate="no">html</code> tag, and not according to the language of the quoted text.  This would remove the unexpected result in a page that contains quotes in another language.</p>
 <p>If, however, the page contains sections in different languages, each with quotations in another language, you will have problems when using the W3C model. The language declared in the <code class="kw" translate="no">html</code> tag will apply throughout, so you'll need to use CSS styling to change the default for one or both sections.</p>
 </section>
-  
+
   <section> </section>
 <section>
 <h3 id="defaults_summary"><a href="#defaults_summary">Summary</a></h3>
@@ -165,7 +165,7 @@ f.additionalLinks = ''
 <h2 id="css_styling"><a href="#css_styling">Using CSS to style quotation marks</a></h2>
 <p>You can style quotation marks for a Swiss French, monolingual document using the following CSS.</p>
 <div class="example">
-<pre>* { quotes: '«' '»' &quot;‹&quot; &quot;›&quot;; } 
+<pre>* { quotes: '«' '»' &quot;‹&quot; &quot;›&quot;; }
 q::before { content: open-quote; }
 q::after { content: close-quote; }</pre>
 </div>


### PR DESCRIPTION
Add a missing quote.

(This commit also removes the trailing whitespace. You can add `?w=1` to the URL to see the diff with whitespace ignored. Thank you!)