### PR TITLE
Spanish name correction

### DIFF
--- a/questions/qa-personal-names.en.html
+++ b/questions/qa-personal-names.en.html
@@ -100,7 +100,7 @@ f.additionalLinks = ''
   
   <section>
     <h3 id="multiplefamily"><a href="#multiplefamily">Multiple family names</a></h3>
-    <p>Spanish-speaking people will commonly have two family names.  For example, <b class="highlight">María-Jose Carreño Quiñones</b> may be the daughter of Antonio Carreño Rodríguez and María Quiñones Marqués.</p>
+    <p>Spanish-speaking people will commonly have two family names.  For example, <b class="highlight">María José Carreño Quiñones</b> (José being a second given name) may be the daughter of Antonio Carreño Rodríguez and María Quiñones Marqués.</p>
     <p>You would refer to her as Señorita Carreño, not Señorita Quiñones.</p>
     <p>Brazilians have similar customs, and may even have three or four family names, drawing on the names of other ancestors, such as <b class="highlight">José Eduardo Santos Tavares Melo Silva</b>.</p>
     <p>Typically,  two Spanish family names would have the order paternal+maternal, whereas Portuguese names in Brazil would be maternal+paternal. However, this order may change.</p>


### PR DESCRIPTION
Hello Richard!

I found a mistake on the name María-Jose Carreño Quiñones, as José would be written with the diacritical mark and separated from María, being María José the correct form of that name without the hyphen. I also added in brackets that José is the second given name of María, as many Spanish-speaking people have two given names.

Kind regards,

Carlos Mateo