### PR TITLE
简体汉语 -> 简体中文

### DIFF
--- a/javascript/boilerplate-text/boilerplate-zh-hans.js
+++ b/javascript/boilerplate-text/boilerplate-zh-hans.js
@@ -32,8 +32,8 @@ s.currLang = {
   'tr':'土耳其文',
   'uk':'乌克兰文',
   'vi':'越南文',
-  'zh-hans':'中文（简体）',
-  'zh-hant':'中文（繁体）',
+  'zh-hans':'简体中文',
+  'zh-hant':'繁体中文',
 }
 
 s.suppStylesheets = ''

--- a/javascript/doc-structure/article.js
+++ b/javascript/doc-structure/article.js
@@ -30,7 +30,7 @@ g.nativeText = {
 'tr':'Türkçe',
 'uk':'Українська',
 'vi':'Tiếng&#xA0;Anh',
-'zh-hans':'简体汉语',
+'zh-hans':'简体中文',
 'zh-hant':'繁體中文'
 }
 

--- a/javascript/doc-structure/article_new.js
+++ b/javascript/doc-structure/article_new.js
@@ -30,7 +30,7 @@ g.nativeText = {
 'tr':'Türkçe',
 'uk':'Українська',
 'vi':'Tiếng&#xA0;Anh',
-'zh-hans':'简体汉语',
+'zh-hans':'简体中文',
 'zh-hant':'繁體中文'
 }
 

--- a/javascript/doc-structure/sitepage.js
+++ b/javascript/doc-structure/sitepage.js
@@ -33,7 +33,7 @@ g.nativeText = {
 'tr':'Türkçe',
 'uk':'Українська',
 'vi':'Tiếng&#xA0;Anh',
-'zh-hans':'简体汉语',
+'zh-hans':'简体中文',
 'zh-hant':'繁體中文'
 }
 

--- a/javascript/doc-structure/sitepage_2021.js
+++ b/javascript/doc-structure/sitepage_2021.js
@@ -33,7 +33,7 @@ g.nativeText = {
 'tr':'Türkçe',
 'uk':'Українська',
 'vi':'Tiếng&#xA0;Anh',
-'zh-hans':'简体汉语',
+'zh-hans':'简体中文',
 'zh-hant':'繁體中文'
 }
 

--- a/pages/translation.zh-hans.html
+++ b/pages/translation.zh-hans.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html lang="zh-hans">
+<head>
+<meta charset="utf-8" />
+<title>翻译说明</title>
+<meta name="description" content="为希望从W3C网站的/International部分翻译文章等的翻译人员提供的说明。" />
+<script>
+var f = { }
+
+// AUTHORS should fill in these assignments:
+f.directory = 'pages'+'/'; // the path to this file, not including /International or the file name
+f.filename = 'translation'; // the file name WITHOUT extensions
+f.authors = 'Richard Ishida, W3C'; // author(s) and affiliations
+f.previousauthors = ''; // as above
+f.modifiers = ''; // people making substantive changes, and their affiliation
+f.searchString = 'level2-translation'; // blog search string - usually the filename without extensions
+f.firstPubDate = '2004-03-12'; // date of the first publication of the document (after review)
+f.lastSubstUpdate = { date:'2016-05-09', time:'08:26'}  // date and time of latest substantive changes to this document
+f.status = 'notreviewed';  // should be one of draft, review, published, notreviewed or obsolete
+f.path = '../' // what you need to prepend to a URL to get to the /International directory 
+
+// AUTHORS AND TRANSLATORS should fill in these assignments:
+f.thisVersion = { date:'2016-05-09', time:'08:26'} // date and time of latest edits to this document/translation
+f.contributors = ''; // people providing useful contributions or feedback during review or at other times
+// also make sure that the lang attribute on the html tag is correct!
+
+// TRANSLATORS should fill in these assignments:
+f.translators = '薛富侨'; // translator(s) and their affiliation - a elements allowed, but use double quotes for attributes
+
+f.breadcrumb = '';
+
+f.additionalLinks = ''
+</script>
+<script src="translation-data/translations.js"> </script>
+<script src="../javascript/doc-structure/article-dt.js"> </script>
+<script src="../javascript/boilerplate-text/boilerplate-zh-hans.js"></script><!--TRANSLATORS must change -en to the subtag for their language!-->
+<script src="../javascript/doc-structure/sitepage.js"> </script>
+<script src="../javascript/articletoc-html5.js"></script>
+
+<link rel="stylesheet" href="../style/sitepage-2016.css" />
+<style>figcaption { font-style: italic; font-size: 90%; text-align: center; }</style>
+<!--link rel="stylesheet" href="translation-data/local.css" /-->
+<link rel="copyright" href="#copyright"/>
+</head>
+
+<body>
+<header>
+  	<nav id="mainNavigation"></nav><script>document.getElementById('mainNavigation').innerHTML = mainNavigation</script>
+	</header>
+<h1>Translation instructions</h1>
+
+<section id="sidebarExtras">
+</section>
+
+
+<div id="mainLayout">
+<section>
+    <p>For ideas on what to translate, take look at the list of <a href="https://www.w3.org/International/articlelist">Articles, best practices &amp; tutorials</a>, select your language at the top right, and look for links that are still in English after the page has refreshed.</p>
+</section>
+
+
+
+
+
+<section>
+    <h2 id="specs"><a href="#specs">W3C Specifications</a></h2>
+
+    <p>To find out how to translate a W3C specification in the <a href="/TR/">https://www.w3.org/TR/</a> space, see <a href="https://www.w3.org/Consortium/Translation/Overview.html">Contributing to W3C Translations</a>. If you want to translate an article or tutorial in the <a href="#i18n">https://www.w3.org/International</a> space, read the rest of this page.</p>
+</section>
+
+
+
+
+
+
+
+<section>
+    <h2 id="i18n"><a href="#i18n">Internationalization pages</a></h2>
+
+    <p>To translate a tutorial or article from the <a href="https://www.w3.org/International/">https://www.w3.org/International/</a> site, please follow
+        the instructions on this page, and confirm that you agree:</p>
+      <ol>
+        <li>to the redistribution terms of the W3C <a href="https://www.w3.org/Consortium/Legal/copyright-documents.html">document copyright
+          notice</a>. Consequently, your translation may be republished by the W3C or other entities if it is done in compliance with the notice's terms.</li>
+        <li>that the W3C may rescind your right to publish or distribute the derivative work if the W3C finds that it leads to confusion
+          regarding the original document's status or integrity. (<a href="https://www.w3.org/Consortium/Legal/IPR-FAQ-20000620#translate">Source.</a>)</li>
+        <li>that any links you add to the document <a href="#linkingrules">must follow the rules in the section entitled 'Links'</a> below.</li>
+      </ol>
+      <p><strong>You need to write to </strong> <a href="mailto:public-i18n-translation@w3.org">public-i18n-translation@w3.org</a> (<a href="https://lists.w3.org/Archives/Public/public-i18n-translation/">archive</a>) <strong>before starting</strong> and copy <a href="mailto:w3c-translators@w3.org">w3c-translators@w3.org</a>. We'll check that the file isn't currently being translated by someone else, and that it isn't about to be updated. You should also indicate that you agree to the conditions on this page.</p>
+      <p><strong>Do not translate the source text of pages displayed on the Web. </strong>It may be out of date, in the middle of an update, or already out for translation, or we may need to update the template or source text before sending to you.</p>
+
+<section>
+    <h3 id="finding"><a href="#finding">Finding a page that needs translation</a></h3>
+
+    <p>To find articles that need translation, go to the <a href="https://www.w3.org/International/articlelist">list of articles</a> and  in the top right of the page click on the language you are interested in. </p>
+    <p>The page will reload. Look down the list for titles that are still in English – these have not been translated.</p>
+    <p>You may also be able to help where content has been updated and we need to adjust the translations. These are listed in the left-most column of the <a href="https://github.com/w3c/i18n-drafts/projects/2">translation radar</a> page.</p>
+    <p> (As mentioned above, before you start you need to also check that the document is really appropriate for translation and get the right source code by contacting <strong> </strong> <a href="mailto:public-i18n-translation@w3.org">public-i18n-translation@w3.org</a>.)</p>
+</section>
+
+
+
+<section>
+    <h3 id="source"><a href="#source">Getting the source text</a></h3>
+
+    <p>You'll want access not only to the text you are intending to translate but also to other files that provide boilerplate text, styling, and scripting transformations to the page.</p>
+    <p>If you are familiar with GitHub, by far the easiest way to proceed is to fork <a href="https://github.com/w3c/i18n-drafts">this repository</a>. This will give you access to all the files you need. (See <a href="https://w3c.github.io/i18n-activity/guidelines/github">Github guidelines for working with i18n documents</a>.)</p>
+      <p>Otherwise, we'll send by email a zipped package containing a subset of the files.  </p>
+    <p>We use boilerplate text that will be incorporated
+        into the displayed page. This approach will speed up your work, improve consistency, and help ensure that non-visible text is translated. If
+    the boilerplate text hasn't yet been translated into your  language, you will be asked to also send a translation of that.</p>
+</section>
+
+
+
+<section>
+    <h3 id="requirements"><a href="#requirements">Guidelines for doing the translation</a></h3>
+
+    <p>If you feel you need to change any markup or style sheet rules, please <a href="mailto:public-i18n-translation@w3.org">contact us</a>. We are open to suggestions, but want to check there are no unintentional side effects. Please inform
+        us also if you plan to adapt, rather than just translate, the content during translation. </p>
+      <p>Do not change any of the JavaScript code, other than the variable values. There are comments in the text to help you identify what to change. Please don't translate the comments either.</p>
+      <p>Sometimes an element will have <code class="kw" translate="no">translate=&quot;no&quot;</code> on it. In principle, the content of these elements should not be translated, except for any subelements with <code class="kw" translate="no">translate=&quot;yes&quot;</code> on them.</p>
+      <p>Don't forget to translate hidden text such as the <code class="kw" translate="no">meta</code> <code class="kw" translate="no">description</code> element, alt text, and so forth. </p>
+      <p>Don't forget to change the value of the <code class="kw" translate="no">lang</code> attribute on the <code class="kw" translate="no">html</code> tag, and as part of the <code class="kw" translate="no">boilerplate-xx.js</code> filename a little lower down.</p>
+    <p>Links to pages below /International should not end with .html (this is to facilitate language negotiation). Please check that all links work before sending the file for publication.</p>
+</section>
+
+
+
+
+
+
+<section>
+    <h3 id="linkingrules"><a href="#linkingrules">Links (Important)</a></h3>
+
+    <p>As a courtesy, we allow you to provide a link from your name to a  page that gives information about you as an individual. The link may also be about your  organization <strong>but if, and only if</strong>,  it  specializes in translation services. We added these restrictions because we found that some people were more interested in linking to commercial pages than providing quality translations.</p>
+    <p>Such links will have a <code class="kw" translate="no">rel</code> attribute set to <strong>nofollow</strong>. </p>
+    <p>For an individual, this should be a personal blog, personal home page, or a bio page. </p>
+    <p>For a translation vendor organization, this could be their home or about page. </p>
+    <p>We will not accept links to pages that, in our view, are overly heavy with links to, or information about, products that are not related to translation.  The purpose of the link should be to provide information to readers of the article about the person or organization doing the translation. Using a link to  any other type of page or site is not acceptable. </p>
+</section>
+
+<section>
+ <h3 id="checklist"><a href="#checklist">Pre-final checks</a></h3>
+
+ <p>Before returning the translated files, please check the following:</p>
+ <p>    <input type="checkbox">
+     The file is <strong>saved  in</strong> the <strong>utf-8</strong> character encoding.</p>
+ <p>
+        <input type="checkbox">
+        Links to files under <strong>https://www.w3.org/International</strong> start with <strong>/International</strong>.</p>
+ <p>
+   <input type="checkbox">
+ Links to <strong>html files on the W3C don't include extensions</strong> (ie. no <code>.html</code>).</p>
+ <p>
+    <input type="checkbox">
+    <strong>img <code class="kw" translate="no">src</code>= attributes</strong>  link to images in the <code class="kw" translate="no">&lt;filename&gt;-data</code> directory.</p>
+ <p>
+   <input type="checkbox">
+ The content of elements that have <code class="kw" translate="no"><strong>translate="no"</strong></code> is not translated.</p>
+   <p>
+     <input type="checkbox">
+     <strong>Variable values</strong> have been provided in the javascript at the top of the page for <code class="kw" translate="no">thisVersion</code>, <code class="kw" translate="no">contributors</code>, and <code class="kw" translate="no">translators</code>.</p>
+   <p>
+     <input type="checkbox">
+     The <strong>value of the <code class="kw" translate="no">lang</code> attribute</strong> in the <code class="kw" translate="no">html</code> tag, and as part of the <code class="kw" translate="no">boilerplate-xx.js</code> filename, lower down, has been changed.</p>
+   <p>
+     <input type="checkbox">
+     The <code class="kw" translate="no">content</code> attribute of the <strong><code class="kw" translate="no">meta description</code></strong> element is translated.</p>
+ <p>
+     <input type="checkbox">
+ There is no remaining <strong>invisible text</strong>, especially <code class="kw" translate="no">alt</code> and <code class="kw" translate="no">title</code> attribute text.</p>
+   <p>
+     <input type="checkbox">
+     <strong><a href="https://validator.w3.org/">The file validates</a></strong> as HTML5.</p>
+</section>
+
+<section>
+<h3 id="returning"><a href="#returning">Send back the translation</a></h3>
+
+<p><strong>Before sending us the translated text, please use the <a href="#checklist">translation checklist</a> to check your
+    text.</strong></p>
+<p>Please ensure that your translation is <a href="https://validator.w3.org/">valid HTML5</a> and uses the UTF-8 character encoding before telling us that the translation is ready.</p>
+  <p>If you are using GitHub, submit a pull request.</p>
+<p>Otherwise, send just the changed files, individually as attachments to an email, to
+  <strong><a href="mailto:public-i18n-translation@w3.org">public-i18n-translation@w3.org</a></strong> for hosting on the W3C site (where we will use language negotiation). No need to send any of the files supplied to you if they weren't changed.</p>
+<p>We will check
+    the file before publication, and get back to you if changes are needed.</p>
+</section>
+
+<section>
+<h3 id="next"><a href="#next">What happens next?</a></h3>
+
+<p>After we received the translation, with any requested modifications, we'll post it to our GitHub staging site, where you can check it. When all is good, we'll publish to the main W3C site and send out an announcement.</p>
+<p>If you are translating more than one article, we'll usually wait for the whole batch to be ready before publishing to the W3C site and announcing.</p>
+</section>
+
+<section>
+  <h3 id="updates"><a href="#updates">Updating pages</a></h3>
+
+  <p>If the English version of a page is updated, a note will be sent to the w3c-translators@w3.org list with information about what changed, and a request for the translator to update their translation.  </p>
+  <p>If the changes are only small additions, such as a new paragraph or a new short section, the English may be added to the translation while awaiting an update. The page will have a banner added to it that says it is out of date, and will point to the English original.</p>
+  <p>If the changes involve substantive or extensive changes, the translation will be removed until an updated version is provided.</p>
+</section>
+</section>
+
+
+  
+<section>
+    <h2><a name="contacts" id="contacts">Contacts</a></h2>
+
+    <ul>
+        <li><a href="mailto:ishida@w3.org">Richard Ishida (ishida@w3.org)</a>, for translation of Internationalization Activity material.</li>
+        <li><a href="mailto:ivan@w3.org">Coralie Mercier (coralie@w3.org)</a>, for translation of other W3C material.</li>
+    </ul>
+
+</section>
+
+</div>
+
+<br style="clear: both;" />
+
+<footer id="thefooter"></footer><script>document.getElementById('thefooter').innerHTML = g.bottomOfPage</script>
+<script>completePage()</script>
+</body>
+</html>

--- a/techniques/sitepage_2021.js
+++ b/techniques/sitepage_2021.js
@@ -33,7 +33,7 @@ g.nativeText = {
 'tr':'Türkçe',
 'uk':'Українська',
 'vi':'Tiếng&#xA0;Anh',
-'zh-hans':'简体汉语',
+'zh-hans':'简体中文',
 'zh-hant':'繁體中文'
 }
 


### PR DESCRIPTION
"简体中文" (means Simplified Chinese) or "中文（简体）" (means Chinese (Simplified)) is more common than "简体汉语". I searched `"简体汉语"` and `"简体中文"` on Google and the number of results was quite different (397,000 vs 1,340,000,000).

I checked other places and the word 简体汉语 is hardly used:

## Examples in W3C

* [clreq](https://github.com/w3c/clreq/blob/d613e4205ae5297ee5dd19710e120a844455ae2a/index.html#L114)
* [Our template](https://github.com/w3c/i18n-drafts/blob/437965b67fd7dedcbaf9e375f8f786ff1baad643/javascript/boilerplate-text/boilerplate-zh-hans.js#L35)
* [Chinese translation of one of our articles](https://github.com/w3c/i18n-drafts/blob/5281311ee2bb461d831781cc61c8356e94d295b7/questions/qa-lang-why.zh-hans.html#L94)
* [WCAG](https://www.w3.org/Translations/#s-WCAG21)
* [Smart Cities Workshop](https://github.com/w3c/smartcities-workshop/blob/f12d3f823c8d69a9efed6dc154464489956d03d4/index.html#L23)

## Example in WHATWG

* [HTML](https://github.com/whatwg/html/wiki/Translations#%E7%AE%80%E4%BD%93%E4%B8%AD%E6%96%87-simplified-chinese)

## Examples outside W3C/WHATWG

Android:
![Android](https://user-images.githubusercontent.com/2863444/144748138-f8d03dd7-b635-465b-a1ba-f6203f691ca4.jpg)

-----

Google:
<img width="871" alt="Google" src="https://user-images.githubusercontent.com/2863444/144748076-3a395623-304e-4c40-a868-5bbcb3881b2e.png">

-----

Facebook:
<img width="1171" alt="Facebook" src="https://user-images.githubusercontent.com/2863444/144748079-2626fae4-8e8c-42bb-81c7-b2d783f937ae.png">


-----

Twitter:
<img width="1125" alt="Twitter" src="https://user-images.githubusercontent.com/2863444/144748087-c43a708b-1179-4c97-b7ff-575dac8d7c27.png">
