### PR TITLE
Adjust the Chinese font stack

### DIFF
--- a/style/article-2022.css
+++ b/style/article-2022.css
@@ -23,6 +23,20 @@
     font-style: normal;
     }
 
+/* From https://github.com/w3c/clreq/blob/gh-pages/local.css */
+@font-face {
+	font-family: 'Punctuation SC';
+	src: local('PingFang SC'), local('Noto Sans SC'), local('Noto Sans CJK SC'), local('Heiti SC'), local('Microsoft Yahei');
+	unicode-range: U+201C, U+201D, U+2018, U+2019, U+2E3A, U+2014, U+2013, U+2026, U+00B7, U+007E, U+002F;
+	/* Unicode range for punctuation marks */
+	}
+
+@font-face {
+	font-family: 'Punctuation TC';
+	src: local('PingFang TC'), local('Noto Sans TC'), local('Noto Sans CJK TC'), local('Heiti TC'), local('Microsoft JhengHei');
+	unicode-range: U+201C, U+201D, U+2018, U+2019, U+2E3A, U+2014, U+2013, U+2026, U+00B7, U+007E, U+002F;
+	/* Unicode range for punctuation marks */
+	}
 
 body {
     line-height: 1.75;
@@ -34,21 +48,6 @@ body {
 	font-family: RalewayWF, Helvetica, 'Helvetica Neue', Arial, "Segoe UI", sans-serif;
 	hyphens: auto;
 	}
-
-/* From https://github.com/w3c/clreq/blob/gh-pages/local.css */
-@font-face {
-	font-family: 'Punctuation SC';
-	src: local('PingFang SC'), local('Noto Sans SC'), local('Noto Sans CJK SC'), local('Heiti SC'), local('Microsoft Yahei');
-	unicode-range: U+201C, U+201D, U+2018, U+2019, U+2E3A, U+2014, U+2013, U+2026, U+00B7, U+007E, U+002F;
-	/* Unicode range for punctuation marks */
-}
-
-@font-face {
-	font-family: 'Punctuation TC';
-	src: local('PingFang TC'), local('Noto Sans TC'), local('Noto Sans CJK TC'), local('Heiti TC'), local('Microsoft JhengHei');
-	unicode-range: U+201C, U+201D, U+2018, U+2019, U+2E3A, U+2014, U+2013, U+2026, U+00B7, U+007E, U+002F;
-	/* Unicode range for punctuation marks */
-}
 
 :root[lang=bg] body, 
 :root[lang=ru] body, 

--- a/style/article-2022.css
+++ b/style/article-2022.css
@@ -34,6 +34,22 @@ body {
 	font-family: RalewayWF, Helvetica, 'Helvetica Neue', Arial, "Segoe UI", sans-serif;
 	hyphens: auto;
 	}
+
+/* From https://github.com/w3c/clreq/blob/gh-pages/local.css */
+@font-face {
+	font-family: 'Punctuation SC';
+	src: local('PingFang SC'), local('Noto Sans SC'), local('Noto Sans CJK SC'), local('Heiti SC'), local('Microsoft Yahei');
+	unicode-range: U+201C, U+201D, U+2018, U+2019, U+2E3A, U+2014, U+2013, U+2026, U+00B7, U+007E, U+002F;
+	/* Unicode range for punctuation marks */
+}
+
+@font-face {
+	font-family: 'Punctuation TC';
+	src: local('PingFang TC'), local('Noto Sans TC'), local('Noto Sans CJK TC'), local('Heiti TC'), local('Microsoft JhengHei');
+	unicode-range: U+201C, U+201D, U+2018, U+2019, U+2E3A, U+2014, U+2013, U+2026, U+00B7, U+007E, U+002F;
+	/* Unicode range for punctuation marks */
+}
+
 :root[lang=bg] body, 
 :root[lang=ru] body, 
 :root[lang=uk] body, 
@@ -78,7 +94,7 @@ body {
 	font-size: 18px;
 	}
 :root[lang=zh-hans] body { 
-	font-family: "SimSun", RalewayWF, Helvetica, Arial, sans-serif; 
+	font-family: 'Punctuation SC', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', 'PingFang SC', 'Noto Sans SC', 'Noto Sans CJK SC', 'Heiti SC', 'DengXian', 'Microsoft YaHei', sans-serif;
 	font-size: 18px;
 	}
 :root[lang=ja] body { 
@@ -90,7 +106,7 @@ body {
 	font-size: 18px;
 	}
 :root[lang=zh-hant] body { 
-	font-family: "MingLiu", RalewayWF, Helvetica, Arial, sans-serif; 
+	font-family: 'Punctuation TC', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', 'PingFang TC', 'Noto Sans TC', 'Noto Sans CJK TC', 'Heiti TC', 'Microsoft JhengHei', sans-serif;
 	font-size: 18px;
 	}
 

--- a/style/sitepage-2022.css
+++ b/style/sitepage-2022.css
@@ -23,6 +23,20 @@
     font-style: normal;
     }
 
+/* From https://github.com/w3c/clreq/blob/gh-pages/local.css */
+@font-face {
+	font-family: 'Punctuation SC';
+	src: local('PingFang SC'), local('Noto Sans SC'), local('Noto Sans CJK SC'), local('Heiti SC'), local('Microsoft Yahei');
+	unicode-range: U+201C, U+201D, U+2018, U+2019, U+2E3A, U+2014, U+2013, U+2026, U+00B7, U+007E, U+002F;
+	/* Unicode range for punctuation marks */
+	}
+
+@font-face {
+	font-family: 'Punctuation TC';
+	src: local('PingFang TC'), local('Noto Sans TC'), local('Noto Sans CJK TC'), local('Heiti TC'), local('Microsoft JhengHei');
+	unicode-range: U+201C, U+201D, U+2018, U+2019, U+2E3A, U+2014, U+2013, U+2026, U+00B7, U+007E, U+002F;
+	/* Unicode range for punctuation marks */
+	}
 
 body {
     line-height: 1.75;
@@ -34,21 +48,6 @@ body {
 	font-family: RalewayWF, Helvetica, 'Helvetica Neue', Arial, "Segoe UI", sans-serif;
 	hyphens: auto;
 	}
-
-/* From https://github.com/w3c/clreq/blob/gh-pages/local.css */
-@font-face {
-	font-family: 'Punctuation SC';
-	src: local('PingFang SC'), local('Noto Sans SC'), local('Noto Sans CJK SC'), local('Heiti SC'), local('Microsoft Yahei');
-	unicode-range: U+201C, U+201D, U+2018, U+2019, U+2E3A, U+2014, U+2013, U+2026, U+00B7, U+007E, U+002F;
-	/* Unicode range for punctuation marks */
-}
-
-@font-face {
-	font-family: 'Punctuation TC';
-	src: local('PingFang TC'), local('Noto Sans TC'), local('Noto Sans CJK TC'), local('Heiti TC'), local('Microsoft JhengHei');
-	unicode-range: U+201C, U+201D, U+2018, U+2019, U+2E3A, U+2014, U+2013, U+2026, U+00B7, U+007E, U+002F;
-	/* Unicode range for punctuation marks */
-}
 
 :root[lang=bg] body, 
 :root[lang=ru] body, 

--- a/style/sitepage-2022.css
+++ b/style/sitepage-2022.css
@@ -34,6 +34,22 @@ body {
 	font-family: RalewayWF, Helvetica, 'Helvetica Neue', Arial, "Segoe UI", sans-serif;
 	hyphens: auto;
 	}
+
+/* From https://github.com/w3c/clreq/blob/gh-pages/local.css */
+@font-face {
+	font-family: 'Punctuation SC';
+	src: local('PingFang SC'), local('Noto Sans SC'), local('Noto Sans CJK SC'), local('Heiti SC'), local('Microsoft Yahei');
+	unicode-range: U+201C, U+201D, U+2018, U+2019, U+2E3A, U+2014, U+2013, U+2026, U+00B7, U+007E, U+002F;
+	/* Unicode range for punctuation marks */
+}
+
+@font-face {
+	font-family: 'Punctuation TC';
+	src: local('PingFang TC'), local('Noto Sans TC'), local('Noto Sans CJK TC'), local('Heiti TC'), local('Microsoft JhengHei');
+	unicode-range: U+201C, U+201D, U+2018, U+2019, U+2E3A, U+2014, U+2013, U+2026, U+00B7, U+007E, U+002F;
+	/* Unicode range for punctuation marks */
+}
+
 :root[lang=bg] body, 
 :root[lang=ru] body, 
 :root[lang=uk] body, 
@@ -78,7 +94,7 @@ body {
 	font-size: 18px;
 	}
 :root[lang=zh-hans] body { 
-	font-family: "SimSun", RalewayWF, Helvetica, Arial, sans-serif; 
+	font-family: 'Punctuation SC', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', 'PingFang SC', 'Noto Sans SC', 'Noto Sans CJK SC', 'Heiti SC', 'DengXian', 'Microsoft YaHei', sans-serif;
 	font-size: 18px;
 	}
 :root[lang=ja] body { 
@@ -90,7 +106,7 @@ body {
 	font-size: 18px;
 	}
 :root[lang=zh-hant] body { 
-	font-family: "MingLiu", RalewayWF, Helvetica, Arial, sans-serif; 
+	font-family: 'Punctuation TC', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', 'PingFang TC', 'Noto Sans TC', 'Noto Sans CJK TC', 'Heiti TC', 'Microsoft JhengHei', sans-serif;
 	font-size: 18px;
 	}
 


### PR DESCRIPTION
Latin fonts are placed before Chinese fonts because some Chinese fonts have ugly English/Cyrillic/Greek glyphs.

For more background, see https://github.com/w3c/clreq/issues/408#issuecomment-1103501409