### PR TITLE
Unify spelling of TR

### DIFF
--- a/questions/qa-scripts.en.html
+++ b/questions/qa-scripts.en.html
@@ -654,7 +654,7 @@ involved to create web pages in a new language.</p>
 <td>3,570,000</td></tr>
 <tr>
 <td>Northern Kurdish [kmr]</td>
-<td>Turkey &amp; several West Asian countries</td>
+<td>Türkiye &amp; several West Asian countries</td>
 <td>Arabic, Latin, (Armenian, Cyrillic)</td>
 <td>15,703,920</td></tr>
 <tr>
@@ -979,7 +979,7 @@ involved to create web pages in a new language.</p>
 <td>11,709,020</td></tr>
 <tr>
 <td>Turkish [tur]</td>
-<td>Turkey</td>
+<td>Türkiye</td>
 <td>Latin, (Arabic)</td>
 <td>88,098,480</td></tr>
 <tr>


### PR DESCRIPTION
This document lists the country Türkiye with both Turkey and Türkiye spelling. Still, when both are present, unless there are other constraints that I accidentally skip, it might be better to use Türkiye everywhere since that now has UN recognition to be primary. This PR aims to do that. Thank you!