### PR TITLE
align datetime value to contents in time

### DIFF
--- a/articles/vertical-text/index-data/digits-pref.html
+++ b/articles/vertical-text/index-data/digits-pref.html
@@ -41,10 +41,10 @@ figure {
 <body>
 <div id="htmlsrc" lang="ja">
 <figure>
-  <p>今日は<time datetime="2016-05-22">2015年5月22日</time>です。</p>
+  <p>今日は<time datetime="2015-05-22">2015年5月22日</time>です。</p>
   </figure>
 <figure class="noNumber">
-  <p>今日は<time datetime="2016-05-22">2015年5月22日</time>です。</p>
+  <p>今日は<time datetime="2015-05-22">2015年5月22日</time>です。</p>
   </figure>
   </div>
   

--- a/articles/vertical-text/index-data/digits.html
+++ b/articles/vertical-text/index-data/digits.html
@@ -37,10 +37,10 @@ figure {
 <body>
 <div id="htmlsrc" lang="ja">
 <figure>
-  <p>今日は<time datetime="2016-05-22">2015年5月22日</time>です。</p>
+  <p>今日は<time datetime="2015-05-22">2015年5月22日</time>です。</p>
   </figure>
 <figure class="noNumber">
-  <p>今日は<time datetime="2016-05-22">2015年5月22日</time>です。</p>
+  <p>今日は<time datetime="2015-05-22">2015年5月22日</time>です。</p>
   </figure>
   </div>
   

--- a/articles/vertical-text/index-data/digits4-pref.html
+++ b/articles/vertical-text/index-data/digits4-pref.html
@@ -40,7 +40,7 @@ figure {
 <body>
 <div id="htmlsrc" lang="ja">
 <figure>
-  <p>今日は<time datetime="2016-05-22">2015年5月22日</time>です。</p>
+  <p>今日は<time datetime="2015-05-22">2015年5月22日</time>です。</p>
   </figure>
   </div>
   

--- a/articles/vertical-text/index-data/digits4.html
+++ b/articles/vertical-text/index-data/digits4.html
@@ -37,7 +37,7 @@ figure {
 <body>
 <div id="htmlsrc" lang="ja">
 <figure>
-  <p>今日は<time datetime="2016-05-22">2015年5月22日</time>です。</p>
+  <p>今日は<time datetime="2015-05-22">2015年5月22日</time>です。</p>
   </figure>
   </div>
   

--- a/articles/vertical-text/index-data/fullwidth-digits-pref.html
+++ b/articles/vertical-text/index-data/fullwidth-digits-pref.html
@@ -41,7 +41,7 @@ figure {
 <body>
 <div id="htmlsrc" lang="ja">
 <figure>
-  <p>今日は<time datetime="2016-05-22">2015年5月22日</time>です。</p>
+  <p>今日は<time datetime="2015-05-22">2015年5月22日</time>です。</p>
   </figure>
   </div>
   

--- a/articles/vertical-text/index-data/fullwidth-digits.html
+++ b/articles/vertical-text/index-data/fullwidth-digits.html
@@ -38,7 +38,7 @@ figure {
 <body>
 <div id="htmlsrc" lang="ja">
 <figure>
-  <p>今日は<time datetime="2016-05-22">2015年5月22日</time>です。</p>
+  <p>今日は<time datetime="2015-05-22">2015年5月22日</time>です。</p>
   </figure>
   </div>
   

--- a/articles/vertical-text/index.en.html
+++ b/articles/vertical-text/index.en.html
@@ -377,7 +377,7 @@ figure pre {
   <p>It only works for digits in the ASCII range, and full-width Unicode codepoints are automatically converted to ASCII codepoints during the process.  It doesn't work for other numbering systems, such as Arabic, Bengali, etc.</p>
   <p>Let's suppose we have some HTML markup like the following, where the date <span lang="ja">2015年5月22日</span> is inside a <code class="kw" translate="no">time</code> element.</p>
   <figure class="example">
-    <p translate="no"><code class="language-html">&lt;p&gt;今日は&lt;time datetime=&quot;2016-05-22&quot;&gt;2015年5月22日&lt;/time&gt;です。&lt;/p&gt;</code></p>
+    <p translate="no"><code class="language-html">&lt;p&gt;今日は&lt;time datetime=&quot;2015-05-22&quot;&gt;2015年5月22日&lt;/time&gt;です。&lt;/p&gt;</code></p>
     </figure>
   <p>We can reproduce the  rendering seen in the above example using the following CSS. </p>
 


### PR DESCRIPTION
Text within time element says `2015年5月22日`, but datetime attribute has `2016-05-22`. This PR fixes these difference.
These are just test cases or pure example for tate-chu-yoko, so there seems no intention to change between attribute and text.