### PR TITLE
update misleading info about default charset in HTTP (fixes #426)

### DIFF
--- a/articles/http-charset/index.en.html
+++ b/articles/http-charset/index.en.html
@@ -68,11 +68,11 @@ character encoding information being sent in an HTTP header</a>.</p>
 
 <section id="charset">
 <h2>The charset parameter</h2>
-  <p>Documents transmitted with HTTP that are of type text, such as text/html, text/plain, etc., can send a <a class="print" href="../Protocols/rfc2068/rfc2068.txt">charset parameter</a> in the HTTP header to specify the character encoding of the document. </p>
-  <p>It is <strong>very important</strong> to always label Web documents explicitly. HTTP 1.1 says that the default charset is
-    ISO-8859-1. But there are too many unlabeled documents in other encodings, so browsers use the reader's preferred encoding when there is no explicit
+  <p>Documents transmitted with HTTP that are of type text, such as text/html, text/plain, etc., can send a <a class="print" href="https://www.rfc-editor.org/rfc/rfc9110#field.content-type">charset parameter</a> in the HTTP header to specify the character encoding of the document. </p>
+  <p>It is <strong>very important</strong> to always label Web documents explicitly. Until 2014 (RFC 7231), HTTP/1.1 used to say that the default charset is
+    ISO-8859-1. But there are too many unlabeled documents in other encodings, so browsers either detect the encoding based on the MIME type, or otherwise use the reader's preferred encoding when there is no explicit
     charset parameter.</p>
-  <p>The line in the HTTP header typically looks like this:</p>
+  <p>The line in the HTTP header field typically looks like this:</p>
   <blockquote><code translate="no">Content-Type: text/html; charset=utf-8</code></blockquote>
   <p>In theory, any character encoding that has been <a class="print" href="http://www.iana.org/assignments/character-sets">registered with IANA</a> can be
     used, but there is no browser that understands all of them. The more widely a character encoding is used, the better the chance that a browser will


### PR DESCRIPTION
This text really needs a rewrite; it apparently hasn't been touched for nearly two decades. This PR applies a minimal fix WRT defaults that do not exist in HTTP anymore.