### PR TITLE
Updated references to qa-mono-multilingual to match the new French tr…

### DIFF
--- a/questions/qa-when-lang-neg.fr.html
+++ b/questions/qa-when-lang-neg.fr.html
@@ -20,7 +20,7 @@ f.status = 'published'  // should be one of draft, review, published, notreviewe
 f.path = '../' // what you need to prepend to a URL to get to the /International directory 
 
 // AUTHORS AND TRANSLATORS should fill in these assignments:
-f.thisVersion = { date:'2016-03-04', time:'16:32'} // date and time of latest edits to this document/translation
+f.thisVersion = { date:'2023-01-09', time:'14:27'} // date and time of latest edits to this document/translation
 f.contributors = '' // people providing useful contributions or feedback during review or at other times
 // also make sure that the lang attribute on the html tag is correct!
 f.sources = '' // describes sources of information

--- a/questions/qa-when-lang-neg.fr.html
+++ b/questions/qa-when-lang-neg.fr.html
@@ -97,8 +97,8 @@ f.additionalLinks = ''
     </ol>
     <p>Conclusion&nbsp;: la négociation de langue ne donne pas toujours le résultat escompté.</p>
     <p id="equivalence">De plus, la négociation de langue n'est même pas <em>pertinente</em> quand les pages ne
-      sont pas équivalentes, c'est à dire quand elles n'ont pas essentiellement le même contenu en des langues différentes. On pourra consulter l'article <a class="print" href="qa-mono-multilingual"><cite>Les sites web unilingues et multilingues</cite></a> à ce sujet, notamment les sous-sections «&nbsp;<em>Multilingue, même
-      contenu</em>&nbsp;» et «&nbsp;<em>Multilingue, contenu changé</em>&nbsp;». Notons toutefois qu'une certaine mesure d'adaptation culturelle (changer
+      sont pas équivalentes, c'est à dire quand elles n'ont pas essentiellement le même contenu en des langues différentes. On pourra consulter l'article <a class="print" href="qa-mono-multilingual"><cite>Sites Web unilingues et multilingues</cite></a> à ce sujet, notamment les sous-sections «&nbsp;<em>Site multilingue, même
+      contenu</em>&nbsp;» et «&nbsp;<em>Site multilingue, contenu différent</em>&nbsp;». Notons toutefois qu'une certaine mesure d'adaptation culturelle (changer
       la devise par ex.) ne rend pas nécessairement les pages non-équivalentes&nbsp;; ce cas se présente vraiment lorsqu'un <em>site</em> est adapté de
       façon à ce que les pages en différentes langues ne correspondent plus.</p>
   </section>


### PR DESCRIPTION
As explained in an email about the new French translation of [questions/qa-mono-multilingual](https://www.w3.org/International/questions/qa-mono-multilingual):

> This article's title and two of its headings were translated in "[questions/qa-when-lang-neg.fr](https://www.w3.org/International/questions/qa-when-lang-neg.fr)". However, I didn't keep these prior translations:
> 
> - Instead of "_Les sites web unilingues et multilingues_", I chose "_Sites Web unilingues et multilingues_" for consistency with another article called "Sites Web internationaux et multilingues".
> - Instead of "_Multilingue, même contenu_", I chose "_Site multilingue, même contenu_".
> - Instead of "_Multilingue, contenu changé_", I chose "_Site multilingue, contenu différent_".