### PR TITLE
Translate qa-changing-encoding into zh-hans

### DIFF
--- a/questions/qa-changing-encoding-data/translations.js
+++ b/questions/qa-changing-encoding-data/translations.js
@@ -1,9 +1,9 @@
 var trans = { }
 
-trans.versions = ['bg','en','fr', 'it']
+trans.versions = ['bg', 'en', 'fr', 'it', 'zh-hans']
 
 trans.outofdatetranslations = []
 
 trans.updatedtranslations = ['bg','fr']
 
-trans.unlinkedtranslations = ['de','es','hi','hu','pl','pt','pt-br','ro','ru','sv','uk','zh-hans']
+trans.unlinkedtranslations = ['de','es','hi','hu','pl','pt','pt-br','ro','ru','sv','uk']

--- a/questions/qa-changing-encoding.bg.html
+++ b/questions/qa-changing-encoding.bg.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <html lang="bg">
 <head>
-<meta charset="utf-8" />
+<meta charset="utf-8">
 <title>Конвертиране на HTML страница към Unicode</title>
-<meta name="description" content="Кад да променя кодировките на моите HTML страници с Unicode/UTF-8?" />
+<meta name="description" content="Кад да променя кодировките на моите HTML страници с Unicode/UTF-8?">
 <script>
 var f = { }
 
@@ -38,8 +38,8 @@ f.additionalLinks = ''
 <!--TRANSLATORS must change -en in the line just above to the subtag for their language! -->
 <script src="../javascript/doc-structure/article-2022.js"> </script>
 <script src="../javascript/articletoc-2022.js"></script>
-<link rel="stylesheet" href="../style/article-2022.css" />
-<link rel="copyright" href="#copyright"/>
+<link rel="stylesheet" href="../style/article-2022.css">
+<link rel="copyright" href="#copyright">
 </head>
 
 <body>
@@ -87,7 +87,7 @@ f.additionalLinks = ''
 	<p>Въпреки че вашите данни са в UTF-8 и сте го декларирали в страницата, възможно е сървърът да предоставя страниците със <a href="/International/articles/definitions-characters/#httpheader">съпровождаща заглавна част на HTTP (хедър)</a> който казва че това е нещо друго.</p>
     <p>Тествайте го като въведете URL-то на страницата си във това поле. То ще ви отведе към <a href="https://validator.w3.org/i18n-checker/">Проверка за интернационализация</a>. Потърсете в таблицата за реда с названието  <samp>HTTP Content-Type</samp>, под <samp>Character Encoding</samp>, и се уверете че стойността е <samp>UTF-8</samp> или <samp>No encoding information found</samp>.</p>
     <form action="https://validator.w3.org/i18n-checker/check" method="get">
-    <p><input type="text" name="uri" style="width:70%;min-width: 10em;"/><button type="submit">Go</button></p>
+    <p><input type="text" name="uri" style="width:70%;min-width: 10em;"><button type="submit">Go</button></p>
     </form>
     <p>Ако HTTP Content-Type е с кодировка различна от UTF-8 ще трябва да <a href="/International/O-HTTP-charset">предприемете мерки за да го коригирате</a>, защото декларацията в HTTP хедъра ще надделе над информацията в страницата.</p>
 	<p>Необходими са ви администраторски права за да промените кодировката на заглавната част на HTTP, въпреки че би могло да го направите сами дори и ако вашите страници се хостват от доставчик на интернет. Консултирайте се с администратора на сървъра. Вижте инструкциите <a href="/International/questions/qa-htaccess-charset">как да направите това за  Apache сървър</a>.</p>

--- a/questions/qa-changing-encoding.en.html
+++ b/questions/qa-changing-encoding.en.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="utf-8" />
+<meta charset="utf-8">
 <title>Changing an HTML page to Unicode</title>
-<meta name="description" content="How do I change the encoding of my HTML pages to Unicode/UTF-8?" />
+<meta name="description" content="How do I change the encoding of my HTML pages to Unicode/UTF-8?">
 <script>
 var f = { }
 
@@ -38,8 +38,8 @@ f.additionalLinks = ''
 <!--TRANSLATORS must change -en in the line just above to the subtag for their language! -->
 <script src="../javascript/doc-structure/article-2022.js"> </script>
 <script src="../javascript/articletoc-2022.js"></script>
-<link rel="stylesheet" href="../style/article-2022.css" />
-<link rel="copyright" href="#copyright"/>
+<link rel="stylesheet" href="../style/article-2022.css">
+<link rel="copyright" href="#copyright">
 </head>
 
 <body>
@@ -98,9 +98,9 @@ f.additionalLinks = ''
     <p>Although your data is in UTF-8 and you have declared it in the page, your server may still be serving the page with an <a href="/International/articles/definitions-characters/#httpheader">accompanying HTTP header</a> that says it is something else.</p>
     <p>Test it by putting the URL of your page in this form. It will take you to the <a href="https://validator.w3.org/i18n-checker/">Internationalization Checker</a>. Look in the table for the row with the title <samp>HTTP Content-Type</samp>, under <samp>Character Encoding</samp>, and check that it says either <samp>UTF-8</samp> or <samp>No encoding information found</samp>.</p>
     <form action="https://validator.w3.org/i18n-checker/check" method="get">
-    <p><input type="text" name="uri" style="width:70%;min-width: 10em;"/><button type="submit">Go</button></p>
+    <p><input type="text" name="uri" style="width:70%;min-width: 10em;"> <button type="submit">Go</button></p>
     </form>
-    <p>If the HTTP Content-Type shows an encoding other than UTF-8 you'll need to <a href="/International/O-HTTP-charset">take steps to rectify it</a>, because the declaration in the HTTP header will override information inside the page</p>
+    <p>If the HTTP Content-Type shows an encoding other than UTF-8 you'll need to <a href="/International/O-HTTP-charset">take steps to rectify it</a>, because the declaration in the HTTP header will override information inside the page.</p>
     <p>Server admin privileges are needed to change the encoding sent in the HTTP header, though you may be able to do so yourself even if
       you are serving files via an ISP. Consult your server admin person. See the explanation of <a href="/International/questions/qa-htaccess-charset">one
       way to do this for an Apache server</a>.</p>

--- a/questions/qa-changing-encoding.fr.html
+++ b/questions/qa-changing-encoding.fr.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <html lang="fr">
 <head>
-<meta charset="utf-8" />
+<meta charset="utf-8">
 <title>Changer l’encodage d’une page HTML en Unicode</title>
-<meta name="description" content="Comment changer l’encodage de mes pages HTML en UTF-8?" />
+<meta name="description" content="Comment changer l’encodage de mes pages HTML en UTF-8?">
 <script>
 var f = { }
 
@@ -38,8 +38,8 @@ f.additionalLinks = ''
 <!--TRANSLATORS must change -en in the line just above to the subtag for their language! -->
 <script src="../javascript/doc-structure/article-2022.js"> </script>
 <script src="../javascript/articletoc-2022.js"></script>
-<link rel="stylesheet" href="../style/article-2022.css" />
-<link rel="copyright" href="#copyright"/>
+<link rel="stylesheet" href="../style/article-2022.css">
+<link rel="copyright" href="#copyright">
 </head>
 
 <body>
@@ -89,7 +89,7 @@ f.additionalLinks = ''
     <p>Même si vos données sont en UTF-8 et que vous l’avez déclaré sur votre page, votre serveur peut toujours présenter la page avec <a href="/International/articles/definitions-characters/#httpheader">une bannière d’accompagnement HTTP</a> disant que c’est autre chose.</p>
     <p>Faites un essai en intégrant l’URL de votre page dans ce format. Cela vous dirigera vers le <a href="https://validator.w3.org/i18n-checker/">contrôleur d’internationalisation</a>. Consultez dans le tableau la ligne comportant le titre <samp>HTTP Content-Type</samp>, sous <samp>Character Encoding</samp>, et vérifiez qu’elle affiche soit <samp>UTF-8</samp> ou <samp>No encoding information found</samp>.</p>
     <form action="https://validator.w3.org/i18n-checker/check" method="get">
-    <p><input type="text" name="uri" style="width:70%;min-width: 10em;"/><button type="submit">Valider</button></p>
+    <p><input type="text" name="uri" style="width:70%;min-width: 10em;"><button type="submit">Valider</button></p>
     </form>
     <p>Si l’élément HTTP Content-Type affiche un encodage autre que l’UTF-8, vous devrez <a href="/International/O-HTTP-charset">prendre des mesures pour le corriger</a>, car la déclaration dans la bannière HTTP ignorera les informations à l’intérieur de la page.</p>
     <p>Les privilèges d’administrateur du serveur sont nécessaires pour modifier l’encodage envoyé dans la bannière HTTP, bien que vous puissiez peut-être le faire vous-même si vous envoyez les fichiers depuis un ISP. Consultez l’administrateur de votre serveur. Consultez ici <a href="/International/questions/qa-htaccess-charset">une méthode pour le faire sur un serveur Apache</a>.</p>

--- a/questions/qa-changing-encoding.it.html
+++ b/questions/qa-changing-encoding.it.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <html lang="it">
 <head>
-<meta charset="utf-8" />
+<meta charset="utf-8">
 <title>Cambiare una pagina HTML in Unicode</title>
-<meta name="description" content="Come posso modificare la codifica delle mie pagine HTML in Unicode / UTF-8?" />
+<meta name="description" content="Come posso modificare la codifica delle mie pagine HTML in Unicode / UTF-8?">
 <script>
 var f = { }
 
@@ -38,8 +38,8 @@ f.additionalLinks = ''
 <!--TRANSLATORS must change -en in the line just above to the subtag for their language! -->
 <script src="../javascript/doc-structure/article-2022.js"> </script>
 <script src="../javascript/articletoc-2022.js"></script>
-<link rel="stylesheet" href="../style/article-2022.css" />
-<link rel="copyright" href="#copyright"/>
+<link rel="stylesheet" href="../style/article-2022.css">
+<link rel="copyright" href="#copyright">
 </head>
 
 <body>
@@ -91,7 +91,7 @@ f.additionalLinks = ''
     <p>Anche se i tuoi dati sono in UTF-8 e tu li hai dichiarati nella pagina, il tuo server potrebbe ancora servire la pagina con un' <a href="/International/articles/definitions-characters/#httpheader">intestazione HTTP di accompagnamento</a> che dice che è qualcos'altro.</p>
     <p>Provatelo mettendo l'URL della vostra pagina in questo modulo. Vi porterà al controllo dell' <a href="https://validator.w3.org/i18n-checker/">Internationalization Checker</a>. Cerca nella tabella la riga con il titolo  <samp>HTTP Content-Type</samp>, sotto <samp>Character Encoding</samp>, e controlla che dica o <samp>UTF-8</samp> o <samp>No encoding information found</samp>.</p>
     <form action="https://validator.w3.org/i18n-checker/check" method="get">
-    <p><input type="text" name="uri" style="width:70%;min-width: 10em;"/><button type="submit">Vai</button></p>
+    <p><input type="text" name="uri" style="width:70%;min-width: 10em;"><button type="submit">Vai</button></p>
     </form>
     <p>Se il Content-Type dell'HTTP mostra una codifica diversa da UTF-8, è necessario <a href="/International/O-HTTP-charset">prendere delle misure per correggerla</a>, perché la dichiarazione nell'intestazione HTTP sovrascriverà le informazioni all'interno della pagina.</p>
     <p>I privilegi di amministratore del server sono necessari per modificare la codifica inviata nell'intestazione HTTP, anche se si può essere in grado di farlo da soli, anche se si servono file tramite un ISP. Consultare il proprio amministratore del server. Vedere la spiegazione di <a href="/International/questions/qa-htaccess-charset">un modo per farlo per un server Apache</a>.</p>

--- a/questions/qa-changing-encoding.zh-hans.html
+++ b/questions/qa-changing-encoding.zh-hans.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="zh-hans">
+<head>
+<meta charset="utf-8">
+<title>将网页的编码更改为Unicode</title>
+<meta name="description" content="如何将HTML页面的编码更改为Unicode/UTF-8？">
+<script>
+var f = { }
+
+// AUTHORS should fill in these assignments:
+f.directory = 'questions'+'/' // the path to this file, not including /International or the file name
+f.filename = 'qa-changing-encoding' // the file name WITHOUT extensions
+f.authors = 'Richard Ishida, W3C' // author(s) and affiliations
+f.previousauthors = '' // as above
+f.modifiers = '' // people making substantive changes, and their affiliation
+f.searchString = 'qa-changing-encoding' // blog search string - usually the filename without extensions
+f.firstPubDate = '2005-08-26' // date of the first publication of the document (after review)
+f.lastSubstUpdate = { date:'2016-05-21', time:'11:32'}  // date and time of latest substantive changes to this document
+f.status = 'published'  // should be one of draft, review, published, notreviewed or obsolete
+f.path = '../' // what you need to prepend to a URL to get to the /International directory
+
+// AUTHORS AND TRANSLATORS should fill in these assignments:
+f.thisVersion = { date:'2023-02-27', time:'17:57'} // date and time of latest edits to this document/translation
+f.contributors = '' // people providing useful contributions or feedback during review or at other times
+// also make sure that the lang attribute on the html tag is correct!
+f.sources = '' // describes sources of information
+
+// TRANSLATORS should fill in these assignments:
+f.translators = '薛富侨' // translator(s) and their affiliation - a elements allowed, but use double quotes for attributes
+
+f.breadcrumb = 'characters'
+
+f.additionalLinks = ''
+</script>
+<script src="qa-changing-encoding-data/translations.js"> </script>
+<script src="../javascript/doc-structure/article-dt.js"> </script>
+<script src="../javascript/boilerplate-text/boilerplate-zh-hans.js"> </script>
+<!--TRANSLATORS must change -en in the line just above to the subtag for their language! -->
+<script src="../javascript/doc-structure/article-2022.js"> </script>
+<script src="../javascript/articletoc-2022.js"></script>
+<link rel="stylesheet" href="../style/article-2022.css">
+<link rel="copyright" href="#copyright">
+
+<script src="../javascript/prism.js"></script>
+<link rel="stylesheet" href="../style/prism.css">
+</head>
+
+<body>
+<header>
+  <nav id="mainNavigation"></nav><script>document.getElementById('mainNavigation').innerHTML = mainNavigation</script>
+
+  <h1>将网页的编码更改为Unicode</h1>
+</header>
+
+
+<div>
+<div id="audience">
+<div id="updateInfo"></div><script>document.getElementById('updateInfo').innerHTML = g.updated</script>
+</div>
+</div>
+
+<p>你可能听说过使用Unicode（UTF-8）而不是Latin1（Windows 1252或ISO 8859-1）或Shift_JIS等传统<a href="https://www.w3.org/International/questions/qa-what-is-encoding">字符编码</a>很<a href="/International/questions/qa-choosing-encodings#useunicode">有用</a>，并且你听说<a href="/International/questions/qa-who-uses-unicode">其他人也在这样做</a>，但你不确定该如何做。</p>
+<p>本页面将帮助你将网页的字符编码更改为UTF-8。</p>
+
+
+
+<section id="answer">
+<h2>答案</h2>
+  <p>下面我们总结了将一个简单的页面转换为Unicode字符编码所需的信息。如果你需要获取有关任何步骤的详细信息，请点击网站上其他文章的链接。</p>
+<p class="info" style="margin-top: 2em;">有关将复杂站点、软件和数据转换为Unicode的更多详细建议，请参阅文章<a href="https://www.w3.org/International/articles/unicode-migration/">迁移到Unicode</a>。</p>
+
+    <section id="savedata">
+<h3>第一步：将文件保存为UTF-8</h3>
+    <p>仅仅将页面内的声明更改为UTF-8编码是不够的，你必须确保文件实际上是以UTF-8格式<strong>保存</strong>的。</p>
+    <p>如果你的文件是手动编辑的，那么你应该使用编辑器将文件保存为UTF-8编码，而不是你原来用的编码。如果你从脚本和数据库构建文件，你应该根据需要转换数据并在你的脚本环境中设置正确的参数。</p>
+    <p>请注意，你可能需要确保数据<a href="/International/questions/qa-utf8-bom">不包含UTF-8签名</a>，也称为字节顺序标记 (BOM)。</p>
+  </section>
+  <section id="declare">
+<h3>第二步：在页面中声明编码</h3>
+
+    <p>你应该<a href="/International/questions/qa-html-encoding-declarations">更改页面中的字符编码声明</a>（如果你还没有声明，则需要添加一个）。</p>
+    <p>最简单的形式看起来如下所示，这应该出现在HTML代码中<code class="kw" translate="no">head</code>元素的开头。</p>
+    <figure class="example">
+    <pre><code class="language-html" translate="no">&lt;meta charset=&quot;utf-8&quot;&gt;</code></pre>
+    </figure>
+  </section>
+
+  <section id="server">
+<h3>第三步：确保你的服务器做着正确的事</h3>
+
+    <p>尽管你的数据是UTF-8格式，你也在页面中声明了它，但你的服务器可能仍然<a href="/International/articles/definitions-characters/#httpheader">附带</a>一个表明它是其他编码的HTTP标头（header）。</p>
+    <p>把页面的URL粘贴到这里来进行测试，它将带你到W3C的<a href="https://validator.w3.org/i18n-checker/">Internationalization Checker</a>。在表中找到标题为<samp>HTTP Content-Type</samp>的行，在<samp>Character Encoding</samp>下，检查它是<samp>UTF-8</samp>还是<samp>No encoding information found</samp>。</p>
+    <form action="https://validator.w3.org/i18n-checker/check" method="get">
+    <p><input type="text" name="uri" style="width:70%;min-width: 10em;"> <button type="submit">Go</button></p>
+    </form>
+    <p>如果HTTP Content-Type显示的编码不是UTF-8，你需要<a href="/International/O-HTTP-charset">采取措施纠正它</a>，因为HTTP标头中的声明将覆盖页面内的信息。</p>
+    <p>虽然通常需要服务器管理员权限才能更改HTTP标头中发送的编码，但即使你通过ISP提供文件，你也可以自己这样做，相关内容请咨询你的服务器管理员。请参阅<a href="/International/questions/qa-htaccess-charset">对Apache服务器执行此操作的一种方法</a>的说明。</p>
+
+  </section>
+</section>
+
+
+<section id="endlinks">
+<h2>进一步阅读</h2>
+<aside class="section" id="survey"> </aside><script>document.getElementById('survey').innerHTML = g.survey</script>
+
+<ul id="full-links">
+    <li>
+      <p>刚刚入门？<a href="/International/getting-started/characters"><cite>介绍字符集与编码</cite></a></p>
+    </li>
+    <li>
+      <p>教程：<a href="/International/tutorials/tutorial-char-enc/"><cite>处理HTML和CSS中的字符编码</cite></a></p>
+    </li>
+    <li>
+      <p><a href="/International/articles/unicode-migration/"><cite>迁移到Unicode</cite></a>：一篇关于将软件和数据更改为Unicode的更深入的文章</p>
+    </li>
+    <li>
+      <p><cite>制作网页</cite></p>
+      <ul>
+        <li><a href="/International/techniques/authoring-html#charset">字符</a></li>
+        <li><a href="/International/techniques/authoring-html#changing">更改到UTF-8</a> </li>
+      </ul>
+  </ul>
+</section>
+
+<footer id="thefooter"></footer><script>document.getElementById('thefooter').innerHTML = g.bottomOfPage</script>
+<script>completePage()</script>
+</body>
+</html>


### PR DESCRIPTION
The Netlify Deploy Preview is 404 because I modified many files and Netlify didn't know which one to show, if we had an `index.html` at the root of this repository, the Page Not Found error wouldn't appear.

To see the preview, just add the corresponding path after the Netlify URL, i.e., https://deploy-preview-451--i18n-drafts.netlify.app/questions/qa-changing-encoding.zh-hans.html