### PR TITLE
Fix a broken link

### DIFF
--- a/nav/participate.html
+++ b/nav/participate.html
@@ -54,7 +54,7 @@ f.additionalLinks = ''
 
 <section id="sidebarExtras">
 <h2 id="i18n" class="notoc"><a href="#i18n">Related</a></h2>
-<p><a href="groups/">List of groups</a></p>
+<p><a href="about#groups">List of groups</a></p>
 </section>
 
 


### PR DESCRIPTION
https://www.w3.org/International/i18n-drafts/nav/groups/ is 404.

https://www.w3.org/International/i18n-drafts/nav/about#groups is probably the correct URL.