### PR TITLE
qa-html-dir: Setting direction on forms manually

### DIFF
--- a/questions/qa-html-dir.html
+++ b/questions/qa-html-dir.html
@@ -390,8 +390,11 @@ etc.
     <p>In some cases you will need to set up your system for this to work. For example, for Internet Explorer you may need to install the Hebrew package <em>and</em> enable the Hebrew keyboard before this will work.</p>
     <p><b class="leadin">Chrome:</b> Right-click on <code class="kw" translate="no">input</code> or <code class="kw" translate="no">textarea</code> elements to reveal the <samp>Writing Direction</samp> submenu. Choose either <samp>Right to Left</samp> or <samp>Left to Right</samp>. This sets the value of the element's <code class="kw" translate="no">dir</code> attribute, which is then available to scripts.</p>
     <p><b class="leadin">Safari:</b> Right-click on <code class="kw" translate="no">input</code> or <code class="kw" translate="no">textarea</code> elements to reveal the <samp>Paragraph Direction</samp> submenu. Choose either <samp>Right to Left</samp> or <samp>Left to Right</samp>. This sets the value of the element's <code class="kw" translate="no">dir</code> attribute, which is then available to scripts.</p>
-    <p><b class="leadin">Firefox:</b> Set direction using the <kbd>CTRL/CMD+SHIFT+X</kbd> keyboard shortcut, which cycles through LTR and RTL. It does not set the value of the element's <code class="kw" translate="no">dir</code> attribute, and is thus invisible to scripts.</p>
+    <p><b class="leadin">Firefox:</b> Set direction using the <kbd>CTRL/CMD+SHIFT+X</kbd> keyboard shortcut, which cycles through LTR and RTL.  This sets the value of the element's <code class="kw" translate="no">dir</code> attribute, which is then available to scripts.</p>
+    
+    <details><summary style="margin-inline-start: 7.5%; margin-inline-end: 32%; font-size: 80%; font-style: italic; cursor: pointer;">Historical information</summary>
     <p><b class="leadin">Internet Explorer:</b> Use <kbd>CTRL+LEFT SHIFT</kbd> for LTR and <kbd>CTRL+RIGHT SHIFT</kbd> for RTL. (These key combinations are also adopted for this purpose by most Microsoft products, e.g. Windows dialogs, Notepad and Word.) They set the value of the element's <code class="kw" translate="no">dir</code> attribute, which is then available to scripts.</p>
+    </details>
 	<p>Try it:</p>
 	<p style="text-align: center;"><textarea style="border: 1px solid #ccc; border-radius: 5px; width: 25em; font-size: 1em;">פעילות הבינאום, W3C!</textarea></p>
   </section>


### PR DESCRIPTION
Manual direction changes in input now set the direction of the input in Firefox  Also, hid IE information.