### PR TITLE
[pages/languagedev_participation.html] minor updates on links/URLs

### DIFF
--- a/pages/languagedev_participation.html
+++ b/pages/languagedev_participation.html
@@ -90,10 +90,10 @@ f.additionalLinks = ''
 <p>How to sign up:</p>
 <ol>
 <li>Find the  group(s) you are interested in – there's a list of group home pages in the right column of this page. For an overview of all work, with links to GitHub repositories, mailing lists, etc, see  the <a href="https://www.w3.org/International/i18n-drafts/nav/about.html#afrlreq">list of groups</a>. </li>
-<li>Take a look at the  home page and the issue list, and check the code of conduct, contributing, and licence information.</li>
+<li>Take a look at the  home page and the issue list, and check the <a href="https://www.w3.org/Consortium/cepc/">code of conduct</a>, contributing, and licence information (<a href="https://www.w3.org/Consortium/Legal/2023/software-license">W3C Software and Document License</a>).</li>
 <li>While on the home page, check out the &quot;<strong>Help Wanted!</strong>&quot; links. These point to typography questions that we hope experts will help us answer.</li>
 <li>Click on the subscribe link and join the mailing list to set up notifications. You will receive a maximum of one email a day (per group) that has a link to relevant GitHub threads that have received comments or been created.</li>
-<li><a href="https://github.com/join?source=prompt-code&source_repo=w3c%2Falreq">Get a GitHub id</a>, so that you can participate in the discussions (really easy, and not privacy invasive).</li>
+<li><a href="https://github.com/join">Get a GitHub id</a>, so that you can participate in the discussions (really easy, and not privacy invasive).</li>
 <li>Add comments to the GitHub issues, or create your own issue(s) if you know of a gap in Web support.</li>
 </ol>
 <p>We use the word 'group' to refer to an area of activity. In some cases there is a constituted task force, where people hold meetings and organise themselves. In other cases, this is a  group of email subscribers focused on a particular region or script, and managed through a GitHub repository.</p>


### PR DESCRIPTION
- I suppose we apply the same CoC (CEPC) and license over all groups, and in some groups these are only referenced from CONTRIBUTING.md. So having links here would help.
- Get a GitHub id link has two parameters (like pointing w3c/alreq as where user jumped from), but we need non of these.

Preview link: https://deploy-preview-476--i18n-drafts.netlify.app/pages/languagedev_participation.html