### PR TITLE
French translation of QA Byte Order Mark

### DIFF
--- a/questions/qa-byte-order-mark.en.html
+++ b/questions/qa-byte-order-mark.en.html
@@ -21,7 +21,7 @@ f.path = '../' // what you need to prepend to a URL to get to the /International
 
 // AUTHORS AND TRANSLATORS should fill in these assignments:
 f.thisVersion = { date:'2016-04-20', time:'11:10'} // date and time of latest edits to this document/translation
-f.contributors = 'Albert Lunde, Asmus Freytag, Björn Höhrmann, Henri Sivonen, John Cowan, Leif Halvard Silli, Norbert Lindenberg' // people providing useful contributions or feedback during review or at other times
+f.contributors = 'Albert Lunde, Asmus Freytag, Björn Höhrmann, Henri Sivonen, John Cowan, Leif Halvard Silli, Norbert Lindenberg, Gwendoline Clavé' // people providing useful contributions or feedback during review or at other times
 // also make sure that the lang attribute on the html tag is correct!
 f.sources = '' // describes sources of information
 
@@ -135,7 +135,7 @@ XHTML/HTML coders (using editors or scripting), script developers (PHP, JSP, etc
 
 <p>In HTML5 browsers are required to recognize the UTF-8 BOM and use it to detect the encoding of the page, and recent versions of major browsers handle the BOM as expected when used for UTF-8 encoded pages.</p>
 
-<p>The UTF-8 BOM offers reliable encoding detection, since it is  extremely short and stable,  works in XML and HTML, and works whether your page is read over the network or not (unlike HTTP declarations). However, bear in mind that it is always a good idea to declare the encoding of your page <a class='termref' href='/International/questions/qa-html-encoding-declarations/#nutshell'>using the <code class="kw" translate="no">meta</code> element</a>, in addition to the BOM, so that the encoding is apparent to people looking at the source text. </p>
+<p>The UTF-8 BOM offers reliable encoding detection, since it is  extremely short and stable,  works in XML and HTML, and works whether your page is read over the network or not (unlike HTTP declarations). However, bear in mind that it is always a good idea to declare the encoding of your page <a href='/International/questions/qa-html-encoding-declarations#nutshell'>using the <code class="kw" translate="no">meta</code> element</a>, in addition to the BOM, so that the encoding is apparent to people looking at the source text. </p>
 
 <p>Also there are a number of situations where the BOM, particularly because it is invisible, may cause a problem. See the section <a href="#problems">Potential issues with the UTF-8 BOM</a> below for more information about those. </p>
 
@@ -156,7 +156,7 @@ XHTML/HTML coders (using editors or scripting), script developers (PHP, JSP, etc
 <div class="sidenoteGroup">
 <p>You can try looking for a UTF-8 signature in your content in your editor, but if your editor handles the BOM correctly you probably won't be able to see it. With a binary editor capable of displaying the hexadecimal byte values in the file, the UTF-8 signature displays as EF BB BF.</p>
 <div class="sideinfonote">
-<p class="info">If your editor or browser applies the wrong character encoding to a UTF-8 encoded file with a BOM, you are likely to see a sequence of bytes at the start of the file. These are the bytes that compose BOM represented as the characters those bytes represent in that encoding. With the Latin 1 (ISO 8859-1) character encoding, the signature displays as characters ï»¿.</p>
+<p class="info">If your editor or browser applies the wrong character encoding to a UTF-8 encoded file with a BOM, you are likely to see a sequence of bytes at the start of the file. These are the bytes that compose BOM represented as the characters those bytes represent in that encoding. With the Latin 1 (ISO 8859-1) character encoding, the signature displays as characters <code>ï»¿</code>.</p>
 </div>
 </div>
 
@@ -225,7 +225,7 @@ XHTML/HTML coders (using editors or scripting), script developers (PHP, JSP, etc
 </div>
 <!--p>According to the HTML specification, the HTTP header overrides any in-document encoding. However, some browsers ignore the HTTP header encoding declaration if the file starts with a BOM, and they assume that the file is encoded as UTF-8.</p-->
 
-<p>In <a href="https://www.w3.org/International/tests/repository/html5/the-input-byte-stream/results-basics#precedence">browsers where the HTTP header still overrides the byte-order mark</a> and the server is declaring pages to have a non-Unicode character encoding, you are likely to find unexpected characters at the start of the page (such as ï»¿ in a page labelled in HTTP as ISO 8859-1) as well as problems displaying non-ASCII characters on the page.</p>
+<p>In <a href="https://www.w3.org/International/tests/repository/html5/the-input-byte-stream/results-basics#precedence">browsers where the HTTP header still overrides the byte-order mark</a> and the server is declaring pages to have a non-Unicode character encoding, you are likely to find unexpected characters at the start of the page (such as <code>ï»¿</code> in a page labelled in HTTP as ISO 8859-1) as well as problems displaying non-ASCII characters on the page.</p>
 </section>
 
 

--- a/questions/qa-byte-order-mark.en.html
+++ b/questions/qa-byte-order-mark.en.html
@@ -53,10 +53,10 @@ f.additionalLinks = ''
 <aside id="sidebarExtras">
 <section>
 <h2 class="notoc">Quick check</h2>
-<form action="https://validator.w3.org/i18n-checker/" method="get" class="quickcheck">
+<form action="https://validator.w3.org/i18n-checker/check" method="get" class="quickcheck">
 <p>Check for byte-order marks in a page</p>
 <p>
-<input type="text" value="URI of page to check" name="docAddr" onfocus="this.value=''">
+<input type="text" value="URI of page to check" name="uri" onfocus="this.value=''">
 </p>
 <p>
 <button type="submit">Check</button>
@@ -135,11 +135,11 @@ XHTML/HTML coders (using editors or scripting), script developers (PHP, JSP, etc
 
 <p>In HTML5 browsers are required to recognize the UTF-8 BOM and use it to detect the encoding of the page, and recent versions of major browsers handle the BOM as expected when used for UTF-8 encoded pages.</p>
 
-<p>The UTF-8 BOM offers reliable encoding detection, since it is  extremely short and stable,  works in XML and HTML, and works whether your page is read over the network or not (unlike HTTP declarations). However, bear in mind that it is always a good idea to declare the encoding of your page using the meta element, in addition to the BOM, so that the encoding is apparent to people looking at the source text. </p>
+<p>The UTF-8 BOM offers reliable encoding detection, since it is  extremely short and stable,  works in XML and HTML, and works whether your page is read over the network or not (unlike HTTP declarations). However, bear in mind that it is always a good idea to declare the encoding of your page <a class='termref' href='/International/questions/qa-html-encoding-declarations/#nutshell'>using the <code class="kw" translate="no">meta</code> element</a>, in addition to the BOM, so that the encoding is apparent to people looking at the source text. </p>
 
-<p>Also there are a number of situations where the BOM, particularly because it is invisible, may cause a problem. See the section below for more information about those. </p>
+<p>Also there are a number of situations where the BOM, particularly because it is invisible, may cause a problem. See the section <a href="#problems">Potential issues with the UTF-8 BOM</a> below for more information about those. </p>
 
-<p>If you use a UTF-16 encoding for your page (and we strongly recommend that you don't), there are some <a href="#bytheway">additional considerations</a>.</p>
+<p>If you use a UTF-16 encoding for your page (and we strongly recommend that you don't), there are some <a href="#additionalinfo">additional considerations</a>.</p>
 </section>
 
 
@@ -239,7 +239,7 @@ XHTML/HTML coders (using editors or scripting), script developers (PHP, JSP, etc
 
 <p>If you use applications or scripts in the back end of your site you should check that they are also able to recognize and handle the BOM.</p>
 
-<p>We strongly recommend that you don't change the encoding of a UTF-8 file from a Unicode encoding to a non-Unicode encoding, but if, for some exceptional reason, you do you must ensure that the BOM is removed. If you don't,  either the browser will continue to treat your content as UTF-8, or you will see strange characters at the beginning of the page.</p>
+<p>We strongly recommend that you don't change the encoding of a UTF-8 file from a Unicode encoding to a non-Unicode encoding, but if you do (for some exceptional reason), you must ensure that the BOM is removed. If you don't,  either the browser will continue to treat your content as UTF-8, or you will see strange characters at the beginning of the page.</p>
 </section>
 </section>
 

--- a/questions/qa-byte-order-mark.fr.html
+++ b/questions/qa-byte-order-mark.fr.html
@@ -135,7 +135,7 @@ XHTML/HTML coders (using editors or scripting), script developers (PHP, JSP, etc
 
 <p>En HTML5, les navigateurs sont tenus de reconnaitre le BOM UTF-8 et de l’utiliser pour détecter l’encodage d’une page. Les versions récentes des principaux navigateurs gèrent l’indicateur d’ordre des octets de la manière attendue lorsqu’il est présent dans des pages encodées en UTF-8.</p>
 
-<p>En plus d’être extrêmement court et stable, le BOM UTF-8 fonctionne en XML et en HTML. Il fonctionne même lorsque votre page n’est pas lue sur le réseau, contrairement aux déclarations HTTP. Par conséquent, il offre un moyen fiable de détecter l’encodage. Gardez toutefois à l’esprit qu’il vaut toujours mieux déclarer l’encodage de votre page <a class='termref' href='/International/questions/qa-html-encoding-declarations/#nutshell'>à l’aide de l’élément <code class="kw" translate="no">meta</code></a> en plus d’utiliser l’indicateur d’ordre des octets. Ainsi, l’encodage est visible des personnes qui consultent le code source. </p>
+<p>En plus d’être extrêmement court et stable, le BOM UTF-8 fonctionne en XML et en HTML. Il fonctionne même lorsque votre page n’est pas lue sur le réseau, contrairement aux déclarations HTTP. Par conséquent, il offre un moyen fiable de détecter l’encodage. Gardez toutefois à l’esprit qu’il vaut toujours mieux déclarer l’encodage de votre page <a href='/International/questions/qa-html-encoding-declarations#nutshell'>à l’aide de l’élément <code class="kw" translate="no">meta</code></a> en plus d’utiliser l’indicateur d’ordre des octets. Ainsi, l’encodage est visible des personnes qui consultent le code source. </p>
 
 <p>Par ailleurs, le BOM peut poser problème dans de nombreuses situations, notamment parce qu’il est invisible. Pour en savoir plus à ce sujet, consultez la section <a href="#problems">Problèmes potentiels liés à l’indicateur d’ordre des octets UTF-8</a>. </p>
 
@@ -156,7 +156,7 @@ XHTML/HTML coders (using editors or scripting), script developers (PHP, JSP, etc
 <div class="sidenoteGroup">
 <p>Vous pouvez aussi chercher une signature UTF-8 en examinant votre contenu dans un éditeur de texte. Cependant, si votre éditeur gère correctement l’indicateur d’ordre des octets, celui-ci sera probablement invisible. Dans un éditeur binaire capable d’afficher les valeurs hexadécimales des octets de votre fichier, la signature UTF-8 s’affiche sous la forme « EF BB BF ».</p>
 <div class="sideinfonote">
-<p class="info">Si votre éditeur ou navigateur applique le mauvais encodage de caractères à un fichier encodé en UTF-8 qui commence par un indicateur d’ordre des octets, vous verrez probablement une séquence d’octets au début de votre fichier. Il s’agit des octets qui composent cet indicateur, affichés sous la forme des caractères qu’ils représentent dans cet encodage. Avec l’encodage de caractères Latin-1 (ISO 8859-1), la signature s’affiche sous la forme des caractères ï»¿.</p>
+<p class="info">Si votre éditeur ou navigateur applique le mauvais encodage de caractères à un fichier encodé en UTF-8 qui commence par un indicateur d’ordre des octets, vous verrez probablement une séquence d’octets au début de votre fichier. Il s’agit des octets qui composent cet indicateur, affichés sous la forme des caractères qu’ils représentent dans cet encodage. Avec l’encodage de caractères Latin-1 (ISO 8859-1), la signature s’affiche sous la forme des caractères <code>ï»¿</code>.</p>
 </div>
 </div>
 
@@ -225,7 +225,7 @@ XHTML/HTML coders (using editors or scripting), script developers (PHP, JSP, etc
 </div>
 <!--p>According to the HTML specification, the HTTP header overrides any in-document encoding. However, some browsers ignore the HTTP header encoding declaration if the file starts with a BOM, and they assume that the file is encoded as UTF-8.</p-->
 
-<p>Dans les <a href="https://www.w3.org/International/tests/repository/html5/the-input-byte-stream/results-basics#precedence">navigateurs pour lesquels l’en-tête HTTP prévaut toujours sur l’indicateur d’ordre des octets</a>, lorsque le serveur déclare que des pages utilisent un encodage de caractères différent d’Unicode, vous aurez probablement deux surprises. D’une part, des caractères inattendus peuvent s’afficher au début de la page (comme ï»¿ dans une page pour laquelle l’en-tête HTTP déclare l’encodage ISO 8859-1). D’autre part, les caractères non ASCII risquent de ne pas s’afficher correctement sur la page.</p>
+<p>Dans les <a href="https://www.w3.org/International/tests/repository/html5/the-input-byte-stream/results-basics#precedence">navigateurs pour lesquels l’en-tête HTTP prévaut toujours sur l’indicateur d’ordre des octets</a>, lorsque le serveur déclare que des pages utilisent un encodage de caractères différent d’Unicode, vous aurez probablement deux surprises. D’une part, des caractères inattendus peuvent s’afficher au début de la page (comme <code>ï»¿</code> dans une page pour laquelle l’en-tête HTTP déclare l’encodage ISO 8859-1). D’autre part, les caractères non ASCII risquent de ne pas s’afficher correctement sur la page.</p>
 </section>
 
 

--- a/questions/qa-byte-order-mark.fr.html
+++ b/questions/qa-byte-order-mark.fr.html
@@ -1,0 +1,319 @@
+﻿<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="utf-8">
+<title>L’indicateur d’ordre des octets (BOM) en HTML</title>
+<meta name="description" content="Qu’est-ce que l’indicateur d’ordre des octets ? Que dois-je savoir à son sujet lorsque je crée du contenu HTML ?">
+<script>
+var f = { }
+
+// AUTHORS should fill in these assignments:
+f.directory = 'questions'+'/' // the path to this file, not including /International or the file name
+f.filename = 'qa-byte-order-mark' // the file name WITHOUT extensions
+f.authors = 'Richard Ishida, W3C' // author(s) and affiliations
+f.previousauthors = '' // as above
+f.modifiers = '' // people making substantive changes, and their affiliation
+f.searchString = 'qa-byte-order-mark' // blog search string - usually the filename without extensions
+f.firstPubDate = '2010-08-10' // date of the first publication of the document (after review)
+f.lastSubstUpdate = { date:'2013-01-31', time:'17:18'}  // date and time of latest substantive changes to this document
+f.status = 'published'  // should be one of draft, review, published, notreviewed or obsolete
+f.path = '../' // what you need to prepend to a URL to get to the /International directory 
+
+// AUTHORS AND TRANSLATORS should fill in these assignments:
+f.thisVersion = { date:'2023-05-30', time:'21:45'} // date and time of latest edits to this document/translation
+f.contributors = 'Albert Lunde, Asmus Freytag, Björn Höhrmann, Henri Sivonen, John Cowan, Leif Halvard Silli, Norbert Lindenberg' // people providing useful contributions or feedback during review or at other times
+// also make sure that the lang attribute on the html tag is correct!
+f.sources = '' // describes sources of information
+
+// TRANSLATORS should fill in these assignments:
+f.translators = 'Gwendoline Clavé, <a href="https://www.clavoline-traduction.fr/" rel="nofollow">Clavoline Traduction</a>'; // translator(s) and their affiliation - a elements allowed, but use double quotes for attributes
+
+f.breadcrumb = 'characters'
+
+f.additionalLinks = ''
+</script>
+<script src="qa-byte-order-mark-data/translations.js"> </script>
+<script src="../javascript/doc-structure/article-dt.js"> </script>
+<script src="../javascript/boilerplate-text/boilerplate-fr.js"> </script>
+<!--TRANSLATORS must change -en in the line just above to the subtag for their language! -->
+<script src="../javascript/doc-structure/article-2022.js"> </script>
+<script src="../javascript/articletoc-2022.js"></script>
+<link rel="stylesheet" href="../style/article-2022.css">
+<link rel="copyright" href="#copyright">
+</head>
+
+<body>
+<header>
+<nav id="mainNavigation"></nav><script>document.getElementById('mainNavigation').innerHTML = mainNavigation</script>
+
+<h1>L’indicateur d’ordre des octets (BOM) en HTML</h1>
+</header>
+
+
+<aside id="sidebarExtras">
+<section>
+<h2 class="notoc">Vérification rapide</h2>
+<form action="https://validator.w3.org/i18n-checker/check" method="get" class="quickcheck">
+<p>Saisissez l’URI d’une page dans le champ ci-dessous pour vérifier si elle contient un ou plusieurs indicateurs d’ordre des octets.</p>
+<p>
+<input type="text" value="URI of page to check" name="uri" onfocus="this.value=''">
+</p>
+<p>
+<button type="submit">Vérifier</button>
+</p>
+<p><span class="guide">Cherchez la ligne « Byte order mark (BOM) » dans la section « Character encoding » du tableau « Information ». Si la page contient des indicateurs d’ordre des octets qui ne se trouvent pas au tout début du fichier, un message d’avertissement s’affichera plus bas.</span></p>
+</form>
+</section>
+</aside>
+
+
+
+
+
+
+
+<div id="audience">
+<!--p><span id="intendedAudience" class="leadin">Intended audience:</span> 
+XHTML/HTML coders (using editors or scripting), script developers (PHP, JSP, etc.), CSS coders, Web project managers, and anyone who  needs to better understand what the BOM is, and how it affects HTML.</p-->
+<div id="updateInfo"></div><script>document.getElementById('updateInfo').innerHTML = g.updated</script>
+</div>
+
+
+
+
+
+
+<section id="question">
+<h2>Questions</h2>
+
+<p class="question">Qu’est-ce que l’indicateur d’ordre des octets ? Que dois-je savoir à son sujet lorsque je crée du contenu HTML ?</p>
+</section>
+
+
+
+
+
+
+
+
+<section id="answer">
+<h2>Réponses</h2>
+
+
+<section id="bomwhat">
+<h3> Qu’est-ce qu’un indicateur d’ordre des octets ?</h3>
+
+<div class="sidenoteGroup">
+<p>Au début d’une page qui utilise un <a class="termref" href="/International/articles/definitions-characters/#charsets">encodage de caractères</a> <a class="termref" href="/International/articles/definitions-characters/#unicode">Unicode</a>, vous pouvez trouver quelques octets qui représentent le point de code Unicode U+FEFF INDICATEUR D’ORDRE DES OCTETS. Son abréviation est « <dfn>BOM</dfn> » d’après le terme anglais « <em>byte-order mark</em> ».</p>
+<div class="insideinfonote">
+<p class="info">Le nom INDICATEUR D’ORDRE DES OCTETS est un alias ; à l’origine, ce caractère s’appelait ESPACE INSÉCABLE SANS CHASSE (abrégé en ZWNBSP d’après le terme anglais « <em>zero width no-break space</em> »). Depuis l’introduction du caractère U+2060 GLUON DE MOTS, le caractère U+FEFF n’est plus utilisé dans son sens d’espace insécable sans chasse. Puisqu’il dispose d’un alias formel, le nom ESPACE INSÉCABLE SANS CHASSE n’est plus utile. Nous utiliserons donc son alias dans cet article.</p>
+</div>
+</div>
+
+<p>Lorsqu’on l’utilise correctement, l’indicateur d’ordre des octets est invisible.</p>
+
+<p>Avant l’introduction d’UTF-8 au début de l’année 1993, on transférait généralement le texte Unicode à l’aide d’un encodage appelé UCS-2 (l’ancêtre d’UTF-16). Dans cet encodage, les caractères étaient représentés par des mots (ou « unités de stockage ») de 16 bits. On pouvait stocker ces mots dans un flux d’octets de deux manières : en commençant par l’octet le plus significatif (ordre <span class="qterm">petit-boutiste</span>) ou par le moins significatif (ordre <span class="qterm">gros-boutiste</span>). Pour préciser dans quel ordre ils étaient stockés, on plaçait le caractère U+FEFF (l’indicateur d’ordre des octets) au début du flux. Il s’agissait d’un nombre magique qui ne faisait pas partie du texte représenté par le flux.</p>
+
+<p>L’image ci-dessous illustre l’ordre des octets dans une séquence de caractères représentés chacun par deux octets. Chaque nombre hexadécimal à deux chiffres représente un octet dans le flux de texte. Comme vous pouvez le voir, avec un mécanisme gros-boutiste, l’ordre des deux octets qui représentent un seul caractère est inversé par rapport au mécanisme petit-boutiste. Le BOM renseigne sur l’ordre utilisé pour permettre aux applications de décoder immédiatement le contenu.</p>
+
+<p><img src="qa-byte-order-mark-data/bom.png" alt="Octets représentant l’indicateur d’ordre des octets."/></p>
+
+<p>Dans l’encodage UTF-8, la présence de l’indicateur d’ordre des octets n’est pas essentielle. En effet, contrairement aux encodages UTF-16, un caractère UTF-8 n’a aucune séquence d’octets alternative. On peut tout de même trouver un BOM dans du texte encodé en UTF-8, soit parce qu’il résulte d’une conversion depuis un autre encodage, soit parce qu’un éditeur de texte l’a ajouté pour signaler que le contenu était encodé en UTF-8. Dans cette situation, on le désigne souvent par le terme <dfn>signature UTF-8</dfn>.</p>
+</section>
+
+
+
+
+
+
+
+
+<section id="bomhow">
+<h3> Que dois-je savoir sur l’indicateur d’ordre des octets ?</h3>
+
+<p>La plupart du temps, vous n’aurez pas à vous soucier du BOM UTF-8. Certains éditeurs de texte (comme le Bloc-Notes de Windows) ajoutent systématiquement un indicateur d’ordre des octets lorsque vous enregistrez un fichier avec l’encodage UTF-8. D’autres vous laissent le choix.</p>
+
+<p>En HTML5, les navigateurs sont tenus de reconnaitre le BOM UTF-8 et de l’utiliser pour détecter l’encodage d’une page. Les versions récentes des principaux navigateurs gèrent l’indicateur d’ordre des octets de la manière attendue lorsqu’il est présent dans des pages encodées en UTF-8.</p>
+
+<p>En plus d’être extrêmement court et stable, le BOM UTF-8 fonctionne en XML et en HTML. Il fonctionne même lorsque votre page n’est pas lue sur le réseau, contrairement aux déclarations HTTP. Par conséquent, il offre un moyen fiable de détecter l’encodage. Gardez toutefois à l’esprit qu’il vaut toujours mieux déclarer l’encodage de votre page <a class='termref' href='/International/questions/qa-html-encoding-declarations/#nutshell'>à l’aide de l’élément <code class="kw" translate="no">meta</code></a> en plus d’utiliser l’indicateur d’ordre des octets. Ainsi, l’encodage est visible des personnes qui consultent le code source. </p>
+
+<p>Par ailleurs, le BOM peut poser problème dans de nombreuses situations, notamment parce qu’il est invisible. Pour en savoir plus à ce sujet, consultez la section <a href="#problems">Problèmes potentiels liés à l’indicateur d’ordre des octets UTF-8</a>. </p>
+
+<p>Si vous utilisez un encodage UTF-16 sur votre page (ce que nous vous déconseillons vivement), voici quelques <a href="#additionalinfo">aspects supplémentaires à prendre en compte</a>.</p>
+</section>
+
+
+
+
+
+
+
+<section id="detect">
+<h3>Détecter l’indicateur d’ordre des octets</h3>
+
+<p>Pour découvrir si une page contient un BOM (au début du contenu ou plus bas), vous pouvez utiliser le <a href="https://validator.w3.org/i18n-checker/">Vérificateur d’internationalisation du W3C</a>. Si un indicateur d’ordre des octets se trouve au début de la page, sa présence sera indiquée dans le tableau « <em>Information</em> ». Si un BOM se trouve plus bas sur la page (par exemple, parce que du contenu est ajouté à la page depuis une source externe), sa présence sera indiquée dans la section « <em>Detailed Report</em> ».</p>
+
+<div class="sidenoteGroup">
+<p>Vous pouvez aussi chercher une signature UTF-8 en examinant votre contenu dans un éditeur de texte. Cependant, si votre éditeur gère correctement l’indicateur d’ordre des octets, celui-ci sera probablement invisible. Dans un éditeur binaire capable d’afficher les valeurs hexadécimales des octets de votre fichier, la signature UTF-8 s’affiche sous la forme « EF BB BF ».</p>
+<div class="sideinfonote">
+<p class="info">Si votre éditeur ou navigateur applique le mauvais encodage de caractères à un fichier encodé en UTF-8 qui commence par un indicateur d’ordre des octets, vous verrez probablement une séquence d’octets au début de votre fichier. Il s’agit des octets qui composent cet indicateur, affichés sous la forme des caractères qu’ils représentent dans cet encodage. Avec l’encodage de caractères Latin-1 (ISO 8859-1), la signature s’affiche sous la forme des caractères ï»¿.</p>
+</div>
+</div>
+
+<p>Autrement, votre éditeur peut indiquer l’encodage de votre fichier dans une barre d’état ou dans un menu, en précisant si la signature UTF-8 s’y trouve ou non. Par exemple, si vous utilisez « Enregistrer sous » dans Dreamweaver avec un fichier qui commence par un BOM, vous constaterez que la case « Inclure une signature Unicode (BOM) » est cochée. Vous pouvez également déterminer dans vos préférences (comme sur l’image ci-dessous) si les nouveaux documents doivent inclure un indicateur d’ordre des octets par défaut.</p>
+
+<p><img src="qa-byte-order-mark-data/dwprefs-bom.png" alt="Préférences relatives à l’indicateur d’ordre des octets dans une boîte de dialogue."/></p>
+</section>
+
+
+
+
+
+
+
+<section id="problems">
+<h3>Problèmes potentiels liés à l’indicateur d’ordre des octets UTF-8</h3>
+
+<p>Vous découvrirez ci-dessous quelques situations dans lesquelles le BOM peut poser problème. </p>
+
+<p>En général, ces problèmes disparaissent avec l’adoption de nouvelles versions de navigateurs et d’outils d’édition. Il est utile de les connaitre si vos utilisateurs et utilisatrices continuent à employer des technologies plus anciennes. Cependant, ce n’est pas qu’une question de compatibilité avec d’anciennes versions. </p>
+
+
+
+
+
+
+<section id="phpincludes">
+<h4>Inclusion de fichier avec PHP</h4>
+
+<p>Au moment de l’écriture de cet article, si vous utilisez la structure PHP <code class="kw" translate="no">include</code> pour inclure dans une page un fichier externe qui commence par un indicateur d’ordre des octets, vous pouvez vous retrouver avec des lignes vierges.</p>
+<p>En effet, puisque le BOM n’est pas retiré avant l’inclusion du fichier dans la page, il se comporte comme un caractère qui occupe une ligne de texte. <a target="examples" href="examples/phpbomtest.php">Voici un exemple</a> dans lequel deux lignes de texte sont incluses à partir de fichiers externes, dont l’un commence par un indicateur d’ordre des octets et l’autre non. Avant la première ligne, on peut voir une ligne vierge.</p>
+
+<p>Avant d’inclure un fichier, vous devriez vous assurer qu’il ne commence pas par un BOM.</p>
+
+<p>Vous pourriez également rencontrer des problèmes avec l’indicateur d’ordre des octets sur une page PHP ordinaire. Lorsque vous envoyez des en-têtes HTTP personnalisés, vous devez appeler le code de définition des en-têtes avant le début de l’affichage. Si un fichier commence par un BOM, la page débute l’affichage avant que les instructions de l’en-tête ne soient interprétées. Cela peut entrainer l’apparition de messages d’erreurs et d’autres problèmes sur la page affichée.</p>
+</section>
+
+
+
+
+
+
+<section id="scripting">
+<h4>Traitement par le code programme</h4>
+
+<p>Veillez à tenir compte de l’indicateur d’ordre des octets dans les scripts ou le code programme qui traitent automatiquement des fichiers dans lesquels il est présent. Par exemple, si vous souhaitez utiliser le filtrage par motif au début d’un fichier qui commence par un BOM, vous devrez compléter votre code de manière à en détecter la présence éventuelle et à l’ignorer le cas échéant. </p>
+
+<p>L’encodage UTF-8 sans indicateur d’ordre des octets a une propriété intéressante. Que l’on utilise l’encodage UTF-8 sans BOM ou l’encodage US-ASCII, un document composé uniquement de caractères de la gamme US-ASCII est encodé de la même manière (à l’octet près !). Il peut donc être traité et compris dans les deux cas. Lorsqu’on y ajoute un indicateur d’ordre des octets, il perd cette propriété, car on y insère alors des octets non ASCII. Par conséquent, si certains de vos processus ou scripts sont conçus pour traiter un contenu composé uniquement de caractères US-ASCII, vous devrez vous passer de BOM.</p>
+</section>
+
+
+
+
+
+
+<section id="transcoding">
+<h4>Priorité des en-têtes HTTP</h4>
+
+<p>HTML5 a introduit des changements importants. Lors de la détection de l’encodage d’une page HTML, l’indicateur d’ordre des octets prévaut désormais sur toute déclaration d’encodage effectuée dans l’en-tête HTTP. Cela peut être très utile lorsque le serveur déclare que des pages utilisent un encodage différent d’UTF-8 et la personne qui a créé la page n’a pas le contrôle sur le paramètre d’encodage des caractères au niveau du serveur (ou n’a pas conscience de son effet). Si le BOM prévaut sur les en-têtes HTTP, l’encodage UTF-8 de la page devrait être correctement identifié. </p>
+
+<div class="sidenoteGroup">
+<p>Au moment de la rédaction de cet article, les navigateurs ne tiennent pas tous compte de ce changement de priorité. Vous ne devriez donc pas considérer que l’ensemble de votre public bénéficie de cette fonctionnalité pour le moment.</p>
+<div class="sideinfonote">
+<p class="info">Dans les versions précédentes d’Internet Explorer, l’indicateur d’ordre des octets prévalait sur les en-têtes HTTP, mais dans IE10 et IE11, c’est l’inverse.</p>
+</div>
+</div>
+<!--p>According to the HTML specification, the HTTP header overrides any in-document encoding. However, some browsers ignore the HTTP header encoding declaration if the file starts with a BOM, and they assume that the file is encoded as UTF-8.</p-->
+
+<p>Dans les <a href="https://www.w3.org/International/tests/repository/html5/the-input-byte-stream/results-basics#precedence">navigateurs pour lesquels l’en-tête HTTP prévaut toujours sur l’indicateur d’ordre des octets</a>, lorsque le serveur déclare que des pages utilisent un encodage de caractères différent d’Unicode, vous aurez probablement deux surprises. D’une part, des caractères inattendus peuvent s’afficher au début de la page (comme ï»¿ dans une page pour laquelle l’en-tête HTTP déclare l’encodage ISO 8859-1). D’autre part, les caractères non ASCII risquent de ne pas s’afficher correctement sur la page.</p>
+</section>
+
+
+
+
+
+
+
+<section id="bom">
+<h4>Autres problèmes</h4>
+
+<p>Si vous utilisez des applications ou des scripts dans le backend de votre site, vous devriez vérifier qu’ils peuvent également reconnaitre et gérer le BOM.</p>
+
+<p>Nous vous déconseillons vivement de modifier l’encodage d’un fichier UTF-8 au profit d’un encodage autre qu’Unicode. Si vous devez tout de même le faire pour une raison exceptionnelle, veillez à retirer l’indicateur d’ordre des octets. Si vous le laissez, les navigateurs continueront à traiter votre contenu comme s’il était encodé en UTF-8 ou vous verrez s’afficher d’étranges caractères au début de votre page.</p>
+</section>
+</section>
+
+
+
+
+
+
+
+<section id="remove">
+<h3>Retirer l’indicateur d’ordre des octets</h3>
+
+<p>Si vous devez retirer l’indicateur d’ordre des octets, vérifiez que votre éditeur de texte vous permet d’ajouter ou de laisser une signature UTF-8 <a href="/International/questions/qa-setting-encoding-in-applications">lors de l’enregistrement du fichier</a>. Il devrait vous permettre de retirer facilement cette signature en ouvrant le fichier puis en l’enregistrant de nouveau. Par exemple, dans des éditeurs comme Notepad++ sous Windows et TextWrangler sous Mac, il est possible de sélectionner l’encodage dans une liste en utilisant la fonctionnalité « Enregistrer sous ». Cette liste permet d’enregistrer un fichier en UTF-8 avec ou sans BOM. Il vous suffit de choisir l’option sans BOM et d’enregistrer.</p>
+
+<p>Si vous utilisez un script, vous avez l’avantage de pouvoir retirer la signature rapidement, y compris dans plusieurs fichiers. Vous pourriez même intégrer l’exécution automatique de ce script à votre processus.</p>
+
+<p>Note : vous devriez évaluer l’impact du retrait de la signature sur votre processus. Il est possible qu’une partie de votre processus de développement de contenu s’appuie sur l’utilisation de la signature pour indiquer qu’un fichier est encodé en UTF-8. Gardez également à l’esprit qu’une page qui contient de nombreux caractères latins peut sembler correcte, mais contenir quelques caractères extérieurs à la gamme ASCII (U+0000 à U+007F) mal encodés.</p>
+</section>
+</section>
+
+
+
+
+
+
+
+
+<section id="additionalinfo">
+<h2>Informations complémentaires</h2>
+
+<p>Voici quelques remarques complémentaires pour les personnes qui encodent leurs pages HTML en UTF-16. Remarque : pour les pages HTML, il est recommandé d’utiliser UTF-8 et d’éviter UTF-16. Pour la plupart des gens, cette section sera donc théorique.</p>
+
+<div class="sidenoteGroup">
+<p>D’après les normes RFC 2718 et Unicode, si vous déclarez l’encodage de caractères UTF-16LE ou UTF-16BE dans l’en-tête HTTP de votre page, vous devriez vous passer d’indicateur d’ordre des octets au début de votre page. L’utilisation d’un BOM n’est appropriée que lorsque le charset IANA « UTF-16 » est précisé dans l’en-tête HTTP de la page.</p>
+<div class="sideinfonote">
+<p class="warning">Remarque : cela concerne uniquement l’<em>étiquetage</em> du contenu. Bien entendu, que vous indiquiez l’encodage UTF-16 en ajoutant un indicateur d’ordre des octets ou que vous indiquiez l’encodage UTF-16LE ou UTF-16BE, la séquence d’octets reste la même.</p>
+</div>
+</div>
+
+<p>La spécification HTML5 interdit actuellement l’utilisation de toute autre déclaration d’encodage textuelle à l’intérieur du document pour les pages qui utilisent l’encodage UTF-16. En pratique, cela signifie que l’indicateur d’ordre des octets constitue lui-même la déclaration que vous devez ajouter.</p>
+
+<p>De la même manière, vous devrez utiliser le BOM si vous déclarez l’encodage UTF-32, mais l’éviter si vous déclarez l’encodage UTF-32BE ou UTF-32LE. Toutefois, si nous n’avons pas mentionné l’encodage UTF-32 jusqu’à présent, c’est parce que son utilisation est vivement déconseillée pour le contenu HTML, et parce que certains navigateurs ne sont plus compatibles avec cet encodage.</p>
+</section>
+
+
+
+
+
+
+
+
+<section id="endlinks">
+<h2>Pour aller plus loin</h2>
+
+<aside class="section" id="survey"> </aside><script>document.getElementById('survey').innerHTML = g.survey</script>
+
+<ul id="full-links">
+<li>
+<p>Vous débutez ? <a href="/International/getting-started/characters"><cite>Introduction aux jeux et encodages de caractères</cite></a></p>
+</li>
+<li>
+<p>Tutoriel, <a href="/International/tutorials/tutorial-char-enc/"><cite>Gestion de l’encodage des caractères en HTML et CSS</cite></a></p>
+</li>
+<li>
+<p>Liens connexes, <cite>Créer du contenu HTML et CSS</cite></p>
+<ul>
+<li><a href="/International/techniques/authoring-html#charset">Caractères</a></li>
+<li><a href="/International/techniques/authoring-html#indoc">Déclarer un encodage de caractères en HTML</a></li>
+</ul>
+</li>
+</ul>
+</section>
+
+<footer id="thefooter"></footer><script>document.getElementById('thefooter').innerHTML = g.bottomOfPage</script>
+<script>completePage()</script>
+</body>
+</html>

--- a/questions/qa-scripts.en.html
+++ b/questions/qa-scripts.en.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <title>Languages using right-to-left scripts</title>
-<meta name="description" content="What directions are commonly localized languages written in?">
+<meta name="description" content="What languages use right-to-left (RTL) scripts? What should you do if a language can be written in more than one script?">
 <script>
 var f = { }
 
@@ -66,7 +66,7 @@ f.additionalLinks = ''
 <section id="question">
 <h2>Question</h2>
 
-<p class="question">What  languages are written with right-to-left scripts?</p>
+<p class="question">What languages are written with right-to-left scripts?</p>
 
 <p>Knowing the directionality of text, based on the <a href="#what" title="What is a script?">script(s)</a> to be used, is important to web designers and authors, because <span class="nobrk">right-to-left</span> text can be more complicated (for beginners) to work with and the organization and directionality of the page layout are affected. Therefore, knowing the writing direction can be relevant to estimating the work
 involved to create web pages in a new language.</p>
@@ -225,7 +225,7 @@ Visual Basic Scripting Edition (VBScript).</blockquote>
 <td>Arabic</td>
 <td>2,864,400</td></tr>
 <tr>
-<td>Brunei [kxd]</td>
+<td>Brunei Malay [kxd]</td>
 <td>Brunei, Malaysia</td>
 <td>Arabic, Latin</td>
 <td>321,000.</td></tr>
@@ -336,7 +336,7 @@ Visual Basic Scripting Edition (VBScript).</blockquote>
 <td>3,722,300</td></tr>
 <tr>
 <td>Egyptian Arabic [arz]</td>
-<td>Egypt, ( widespread media)</td>
+<td>Egypt, (widespread media)</td>
 <td>Arabic</td>
 <td>74,826,320</td></tr>
 <tr>
@@ -741,7 +741,7 @@ Visual Basic Scripting Edition (VBScript).</blockquote>
 <td>5,398,700.</td></tr>
 <tr>
 <td>Pular [fuf]</td>
-<td>Guinea, Mail</td>
+<td>Guinea, Mali</td>
 <td>Latin, Arabic, Adlam</td>
 <td>4,778,200</td></tr>
 <tr>
@@ -765,7 +765,7 @@ Visual Basic Scripting Edition (VBScript).</blockquote>
 <td>Arabic, Latin</td>
 <td>200,000</td></tr>
 <tr>
-<td>SaidiArabic [aec]</td>
+<td>Saʽidi Arabic [aec]</td>
 <td>Egypt, Libya</td>
 <td>Arabic</td>
 <td>24,100,000</td></tr>
@@ -816,7 +816,7 @@ Visual Basic Scripting Edition (VBScript).</blockquote>
 <td>21,930,230</td></tr>
 <tr>
 <td>Soninke [snk]</td>
-<td>Mail &amp; neighbours</td>
+<td>Mali &amp; neighbours</td>
 <td>Latin, Arabic</td>
 <td>2,189,250</td></tr>
 <tr>
@@ -1031,7 +1031,7 @@ Visual Basic Scripting Edition (VBScript).</blockquote>
 <td>52,200</td></tr>
 <tr>
 <td>Western Balochi [bgn]</td>
-<td>Pakistan, Turmenistan</td>
+<td>Pakistan, Turkmenistan</td>
 <td>Arabic, Cyrillic</td>
 <td>2,264,350</td></tr>
 <tr>
@@ -1096,7 +1096,7 @@ Visual Basic Scripting Edition (VBScript).</blockquote>
 
 <tr>
 <td>Hanifi Rohingya</td>
-<td>Rohingya</td>
+<td>Rohingya [rhg]</td>
 <td>Myanmar, Bangladesh</td>
 <td>Hanifi Rohingya, Arabic, Latin</td>
 <td> 2,529,250</td>
@@ -1162,7 +1162,7 @@ Visual Basic Scripting Edition (VBScript).</blockquote>
 
 <tr>
 <td>Mandaic</td>
-<td>Neo-Mandaic</td>
+<td>Neo-Mandaic [mid]</td>
 <td>Iran</td>
 <td>Mandaic</td>
 <td>23,000</td>
@@ -1174,7 +1174,7 @@ Visual Basic Scripting Edition (VBScript).</blockquote>
 
 <tr>
 <td>Mende Kikakui</td>
-<td>Mende</td>
+<td>Mende [men]</td>
 <td> Liberia, Sierra Leone</td>
 <td>Latin (Mende Kikakui)</td>
 <td>2,511,600</td>
@@ -1224,7 +1224,7 @@ Visual Basic Scripting Edition (VBScript).</blockquote>
 
 <tr>
 <td>Old Hungarian</td>
-<td>Hungarian</td>
+<td>Hungarian [hun]</td>
 <td>Hungary</td>
 <td>Latin, (Old Hungarian)</td>
 <td>12,560,490</td>
@@ -1237,7 +1237,7 @@ Visual Basic Scripting Edition (VBScript).</blockquote>
 
 <tr>
 <td>Samaritan</td>
-<td>Samaritan</td>
+<td>Samaritan Aramaic [sam]</td>
 <td>Israel, Palestine</td>
 <td>Hebrew, Samaritan</td>
 <td>(liturgical)</td>
@@ -1294,9 +1294,9 @@ Visual Basic Scripting Edition (VBScript).</blockquote>
 
 <tr>
 <td>Yezidi</td>
-<td>Northern Kurdish</td>
-<td>Türkiye,  Iraq, Iran, Syria Armenia</td>
-<td>Arabic, Cyrillic, Latin(Yezidi)</td>
+<td>Northern Kurdish [kmr]</td>
+<td>Türkiye,  Iraq, Iran, Syria, Armenia</td>
+<td>Arabic, Cyrillic, Latin (Yezidi)</td>
 <td>15,703,920</td>
 </tr>
 
@@ -1339,25 +1339,25 @@ Visual Basic Scripting Edition (VBScript).</blockquote>
 <li>
 <p>Related links, <cite>Authoring HTML &amp; CSS</cite></p>
 <ul>
-<li><a href="https://www.w3.org/International/techniques/authoring-html#direction">Text direction</a></li>
+<li><a href="/International/techniques/authoring-html#direction">Text direction</a></li>
 </ul>
 </li>
 <li>
-<p><a href="https://www.ethnologue.com/">SIL Ethnologue</a> (A good
-resource for information about languages.)</p>
+<p><a href="https://www.ethnologue.com/">SIL Ethnologue</a>: A good
+resource for information about languages.</p>
 </li>
 <!--li>
 <p><a href="http://www.ontopia.net/i18n/direction.jsp?id=rtl">Ontopia, Lars Marius Garshol's page on <span class="nobr">right-to-left</span> scripts</a></p>
 </li-->
 <li>
-<p><a href="https://www.omniglot.com/">Omniglot</a> (A guide to writing systems.)</p>
+<p><a href="https://www.omniglot.com/">Omniglot</a>: A guide to writing systems.</p>
 </li>
 <li>
-<p><a href="https://www.rosettaproject.org/">Rosetta Project</a> (A collection
-of descriptions, texts, analytic materials and audio files for 1,000 languages.)</p>
+<p><a href="https://www.rosettaproject.org/">Rosetta Project</a>: A collection
+of descriptions, texts, analytic materials and audio files for 1,000 languages.</p>
 </li>
 <li>
-<p><a href="https://r12a.github.io/scripts/#scriptnotes">Orthography descriptions</a></p>
+<p><a href="https://r12a.github.io/scripts/#scriptnotes">Orthography descriptions</a>: Notes summarising the key features of a given script or orthography.</p>
 </li>
 </ul>
 </section>

--- a/questions/qa-scripts.en.html
+++ b/questions/qa-scripts.en.html
@@ -40,6 +40,8 @@ f.additionalLinks = ''
 <script src="../javascript/articletoc-2022.js"></script>
 <link rel="stylesheet" href="../style/article-2022.css">
 <link rel="copyright" href="#copyright">
+
+<style>tr td:last-child {text-align:right;}</style>
 </head>
 
 <body>
@@ -125,17 +127,32 @@ Visual Basic Scripting Edition (VBScript).</blockquote>
 <section id="directions">
 <h3>What languages use RTL scripts?</h3>
 
-<p>The following table gives a rough idea of modern spoken languages that can be written using RTL scripts, and where they are spoken. Some of the smaller languages are not mentioned. This data is gathered from information in the <a href="https://www.ethnologue.com">SIL Ethnologue</a>.</p>
+<p>The following table gives a rough idea of modern spoken languages that can be written using RTL scripts, and where they are spoken. In addition:</p>
 
 <ul>
 <li>The <samp>Script Usage</samp> column shows all scripts that can be used for that language: the relative order gives a rough idea of frequency of use, and where the script usage is minor it appears in parentheses.</li>
 <li>The <samp>Potential Users</samp> column lists the number of overall speakers of that language (native and second language users). The figures don't take into account users of liturgical languages.</li>
 </ul>
 
+<p>This data is gathered from information in the <a href="https://www.ethnologue.com">SIL Ethnologue</a>.</p>
+
+<h4>How many languages are written from right to left?</h4>
+
+<p>The table lists 12 scripts, and 215 languages. Some of the smaller languages are not mentioned.</p>
+
+<div class="sidenoteGroup">
+    <p>Arabic accounts for a large proportion, with 189 languages and just over 2 billion potential users. No distinction is made between the various styles of Arabic, such as Nastaliq, Magribi, Kano, etc., nor between the orthographies that are <a class="termref" href="https://w3c.github.io/i18n-glossary/#dfn-abjad">abjads</a> and those that are <a class="termref" href="https://w3c.github.io/i18n-glossary/#dfn-alphabet">alphabets</a>. Nor, as mentioned, does it take into account the number of people using Arabic because of their religion.</p>
+
+    <aside class="sideinfonote">
+        <p class="info">The Arabic script (or orthography) includes short vowels represented by diacritics.</p>
+        <p>When this script is used to represent the Arabic language, short vowels diacritics are omitted. In that case, the Arabic script is referred to as an “abjad”, just like Syriac and Urdu scripts.</p>
+        <p>On the other hand, when this script is used to write some other languages (such as Kashmiri, Uighur, and most African languages), all vowels are represented, including short vowels. The Arabic script is then an “alphabet”.</p>
+    </aside>
+</div>
+
+<h4>How many people use right-to-left scripts?</h4>
+
 <p>The total number of potential users is of course an overestimate, because it doesn't take into account literacy levels or competing scripts or usage trends. Nonetheless, at 2,305,048,719 it indicates that the actual number of potential users possibly runs past a billion.</p>
-
-<p>The table lists 12 scripts, and 215 languages. Arabic accounts for a large proportion, with 189 languages and just over 2 billion potential users. No distinction is made between the various styles of Arabic, such as Nastaliq, Magribi, Kano, etc., nor between the orthographies that are <a class="termref" href="https://w3c.github.io/i18n-glossary/#dfn-abjad">abjads</a> and those that are <a class="termref" href="https://w3c.github.io/i18n-glossary/#dfn-alphabet">alphabets</a>. Nor, as mentioned, does it take into account the number of people using Arabic because of their religion.</p>
-
 
 <table class="inband" id="table2">
 <tbody>

--- a/questions/qa-scripts.en.html
+++ b/questions/qa-scripts.en.html
@@ -21,7 +21,7 @@ f.path = '../' // what you need to prepend to a URL to get to the /International
 
 // AUTHORS AND TRANSLATORS should fill in these assignments:
 f.thisVersion = { date:'2022-06-15', time:'15:10'} // date and time of latest edits to this document/translation
-f.contributors = '' // people providing useful contributions or feedback during review or at other times
+f.contributors = 'Gwendoline Clavé' // people providing useful contributions or feedback during review or at other times
 // also make sure that the lang attribute on the html tag is correct!
 f.sources = '' // describes sources of information
 
@@ -1343,21 +1343,21 @@ Visual Basic Scripting Edition (VBScript).</blockquote>
 </ul>
 </li>
 <li>
-<p><a href="https://www.ethnologue.com/">SIL Ethnologue</a>: A good
-resource for information about languages.</p>
+<p><a href="https://www.ethnologue.com/">SIL Ethnologue</a> (A good
+resource for information about languages.)</p>
 </li>
 <!--li>
 <p><a href="http://www.ontopia.net/i18n/direction.jsp?id=rtl">Ontopia, Lars Marius Garshol's page on <span class="nobr">right-to-left</span> scripts</a></p>
 </li-->
 <li>
-<p><a href="https://www.omniglot.com/">Omniglot</a>: A guide to writing systems.</p>
+<p><a href="https://www.omniglot.com/">Omniglot</a> (A guide to writing systems.)</p>
 </li>
 <li>
-<p><a href="https://www.rosettaproject.org/">Rosetta Project</a>: A collection
-of descriptions, texts, analytic materials and audio files for 1,000 languages.</p>
+<p><a href="https://www.rosettaproject.org/">Rosetta Project</a> (A collection
+of descriptions, texts, analytic materials and audio files for 1,000 languages.)</p>
 </li>
 <li>
-<p><a href="https://r12a.github.io/scripts/#scriptnotes">Orthography descriptions</a>: Notes summarising the key features of a given script or orthography.</p>
+<p><a href="https://r12a.github.io/scripts/#scriptnotes">Orthography descriptions</a> (Notes summarising the key features of a given script or orthography.)</p>
 </li>
 </ul>
 </section>

--- a/questions/qa-scripts.en.html
+++ b/questions/qa-scripts.en.html
@@ -68,7 +68,9 @@ f.additionalLinks = ''
 
 <p class="question">What languages are written with right-to-left scripts?</p>
 
-<p>Knowing the directionality of text, based on the <a href="#what" title="What is a script?">script(s)</a> to be used, is important to web designers and authors, because <span class="nobrk">right-to-left</span> text can be more complicated (for beginners) to work with and the organization and directionality of the page layout are affected. Therefore, knowing the writing direction can be relevant to estimating the work
+<p>The directionality of a language depends on the <a href="#what" title="What is a script?">script(s)</a> to be used.</p>
+
+<p>Knowing the directionality of text is important to web designers and authors, because <span class="nobrk">right-to-left</span> text can be more complicated (for beginners) to work with and the organization and directionality of the page layout are affected. Therefore, knowing the writing direction can be relevant to estimating the work
 involved to create web pages in a new language.</p>
 </section>
 
@@ -89,7 +91,7 @@ involved to create web pages in a new language.</p>
 
 <blockquote>Script: a collection of symbols used to represent text in one or more writing systems.</blockquote>
 
-<p>Microsoft offers the following definition on their <a class="print" href="https://msdn.microsoft.com/en-us/goglobal/bb964658#s">globalization web site</a>:</p>
+<p>At the time this article was written, Microsoft offered the following definition on their <a class="print" href="https://msdn.microsoft.com/en-us/goglobal/bb964658#s">globalization web site</a>:</p>
 
 <blockquote>Script: A collection of characters for displaying written text, all of which have a common characteristic that justifies
 their consideration as a distinct set. One script can be used for several different languages (for example, Latin script, which covers all of Western
@@ -121,11 +123,18 @@ Visual Basic Scripting Edition (VBScript).</blockquote>
 
 
 <section id="directions">
-<h3>What  languages use RTL scripts?</h3>
+<h3>What languages use RTL scripts?</h3>
 
-<p>The following table gives a rough idea of modern spoken languages that can be written using RTL scripts, and where they are spoken. This data is gathered from information in the <a href="https://www.ethnologue.com">SIL Ethnologue</a>. The <samp>Script Usage</samp> column shows all scripts that can be used for that language: the relative order gives a rough idea of frequency of use, and where the script usage is minor it appears in parentheses. The <samp>Potential Users</samp> column lists the number of overall speakers of that language (native and second language users). Some of the smaller languages are not mentioned, and the figures don't take into account users of liturgical languages.</p>
+<p>The following table gives a rough idea of modern spoken languages that can be written using RTL scripts, and where they are spoken. Some of the smaller languages are not mentioned. This data is gathered from information in the <a href="https://www.ethnologue.com">SIL Ethnologue</a>.</p>
 
-<p>The total number of potential users is of course an overestimate, because it doesn't take into account literacy levels or competing scripts or usage trends. Nonetheless, at 2,305,048,719 it indicates that the actual number of potential users possibly runs past a billion. The table lists 12 scripts, and 215 languages. Arabic accounts for a large proportion, with 189 languages and just over 2 billion potential users. No distinction is made between the various styles of Arabic, such as Nastaliq, Magribi, Kano, etc, or those that are abjads and those that are alphabetic. Nor, as mentioned, does it take into account the number of people using Arabic because of their religion.</p>
+<ul>
+<li>The <samp>Script Usage</samp> column shows all scripts that can be used for that language: the relative order gives a rough idea of frequency of use, and where the script usage is minor it appears in parentheses.</li>
+<li>The <samp>Potential Users</samp> column lists the number of overall speakers of that language (native and second language users). The figures don't take into account users of liturgical languages.</li>
+</ul>
+
+<p>The total number of potential users is of course an overestimate, because it doesn't take into account literacy levels or competing scripts or usage trends. Nonetheless, at 2,305,048,719 it indicates that the actual number of potential users possibly runs past a billion.</p>
+
+<p>The table lists 12 scripts, and 215 languages. Arabic accounts for a large proportion, with 189 languages and just over 2 billion potential users. No distinction is made between the various styles of Arabic, such as Nastaliq, Magribi, Kano, etc., nor between the orthographies that are <a class="termref" href="https://w3c.github.io/i18n-glossary/#dfn-abjad">abjads</a> and those that are <a class="termref" href="https://w3c.github.io/i18n-glossary/#dfn-alphabet">alphabets</a>. Nor, as mentioned, does it take into account the number of people using Arabic because of their religion.</p>
 
 
 <table class="inband" id="table2">
@@ -141,7 +150,7 @@ Visual Basic Scripting Edition (VBScript).</blockquote>
 <td rowspan="2">Adlam</td>
 <td>Fulah [ful]</td>
 <td>Guinea, Mali, Nigeria, Niger, Chad</td>
-<td>Latin,  Adlam</td>
+<td>Latin, Adlam</td>
 <td>35,337,640</td>
 </tr>
 <tr>
@@ -180,9 +189,9 @@ Visual Basic Scripting Edition (VBScript).</blockquote>
 <td>Arabic</td>
 <td>26,400</td></tr>
 <tr>
-<td>Azerbaijani [aze] (azj, azb)</td>
+<td>Azerbaijani/Azeri [aze] (azj, azb)</td>
 <td>Azerbaijan, Iran</td>
-<td>Arabic, Latin</td>
+<td>Arabic, Latin, (Cyrillic)</td>
 <td>23,849,330</td></tr>
 <tr>
 <td>Baharna Arabic [abv]</td>
@@ -362,7 +371,7 @@ Visual Basic Scripting Edition (VBScript).</blockquote>
 <tr>
 <td>Gujari [gju]</td>
 <td>India</td>
-<td>Arabic,  (Devanagari)</td>
+<td>Arabic, (Devanagari)</td>
 <td>1,696,000</td></tr>
 <tr>
 <td>Gulf Arabic [afb]</td>
@@ -1295,7 +1304,7 @@ Visual Basic Scripting Edition (VBScript).</blockquote>
 <tr>
 <td>Yezidi</td>
 <td>Northern Kurdish [kmr]</td>
-<td>Türkiye,  Iraq, Iran, Syria, Armenia</td>
+<td>Türkiye, Iraq, Iran, Syria, Armenia</td>
 <td>Arabic, Cyrillic, Latin (Yezidi)</td>
 <td>15,703,920</td>
 </tr>
@@ -1306,7 +1315,9 @@ Visual Basic Scripting Edition (VBScript).</blockquote>
 
 
 
-<p>The table doesn't include historical usage of scripts. For example, the Arabic script was formerly used throughout the Ottoman Empire and in many Central Asian regions. Other RTL scripts are not listed in the table because they are no longer  used  for modern communication, although academics and students around the world do need to be able to work with them. These include scripts such as Avestan, Minoan, Hatran, Imperial Aramaic, Kharoshthi, Lydian, Manichaean, Nabataean, Pahlavi, Palmyrene, Parthian, and Pheonician.</p>
+<p>The table doesn't include historical usage of scripts. For example, the Arabic script was formerly used throughout the Ottoman Empire and in many Central Asian regions.</p>
+
+<p>Other RTL scripts are not listed in the table because they are no longer used for modern communication, although academics and students around the world do need to be able to work with them. These include scripts such as Avestan, Minoan, Hatran, Imperial Aramaic, Kharoshthi, Lydian, Manichaean, Nabataean, Pahlavi, Palmyrene, Parthian, and Pheonician.</p>
 </section>
 
 
@@ -1317,11 +1328,23 @@ Visual Basic Scripting Edition (VBScript).</blockquote>
 <section id="whichscript">
 <h3>Which script should I use?</h3>
 
-<p>If a language can be written in more than one script, which script should a web designer or localizer use, or should the text be provided in all scripts?</p>
+<p><strong>If a language can be written in more than one script, which script should a web designer or localizer use, or should the text be provided in all scripts?</strong></p>
 
-<p>The answer will depend on your target audience. The script may change for different countries or regions. The script may also change by legislation or with changes in government policy. For example, to reach the Azeri-speaking population in Iran, you would use Arabic script. From the late 1930s, Cyrillic was the script of choice in Azerbaijan itself and became policy in 1940. Due to the fall of the Soviet Union, beginning in 1991 a gradual switch to Latin occured, becoming mandatory for official uses in 2001. However, for your target audience and unofficial uses, you might want to use Cyrillic for older audiences and Latin for younger audiences, and most likely both to reach the general Azerbaijani population. If you want to reach all Azeri speakers, you would use all 3 scripts. (Note that there might be terminology and other differences among Azeri speakers in different countries, just as there are differences between English or French speakers in different countries.)</p>
+<p>The answer will depend on your target audience. The script may change for different countries or regions. The script may also change by legislation or with changes in government policy. For example, let's go back to Azeri, which can be written in any of the Latin, Cyrillic, or Arabic scripts:</p>
 
-<p>You also should be aware that your choice of script may have political, religious, demographic or cultural overtones. In countries where the language of higher learning was Russian, Cyrillic will be used by educated people. Latin is associated with Pan-Turkic movements, and more generally can indicate Western-tending movements. Arabic script has associations with Islamist movements.</p>
+<ul>
+<li>To reach the Azeri-speaking population <strong>in Iran</strong>, you would use <strong>Arabic script</strong>.</li>
+<li>In <strong>Azerbaijan</strong> itself, <strong>Cyrillic</strong> was the script of choice from the late 1930s, and became policy in 1940. Due to the fall of the Soviet Union, beginning in 1991 a gradual switch to <strong>Latin</strong> occured, becoming mandatory for official uses in 2001. However, for your target audience and unofficial uses, you might want to use <strong>Cyrillic</strong> for older audiences and <strong>Latin</strong> for younger audiences, and most likely <strong>both</strong> to reach the general Azerbaijani population.</li>
+<li>If you want to reach <strong>all Azeri speakers</strong>, you would use <strong>all 3 scripts</strong>. (Note that there might be terminology and other differences among Azeri speakers in different countries, just as there are differences between English or French speakers in different countries.)</li>
+</ul>
+
+<p>You also should be aware that your choice of script may have political, religious, demographic or cultural overtones. For instance:</p>
+
+<ul>
+<li>In countries where the language of higher learning was Russian, <strong>Cyrillic</strong> will be used by educated people.</li>
+<li><strong>Latin</strong> is associated with Pan-Turkic movements, and more generally can indicate Western-tending movements.</li>
+<li><strong>Arabic</strong> script has associations with Islamist movements.</li>
+</ul>
 
 <p>More generally, just as you research which languages are required to serve different cultures, you may need to investigate the correct script or scripts to use. There are suggestions in <a href="#directions">the table</a> above.</p>
 </section>

--- a/questions/qa-scripts.fr.html
+++ b/questions/qa-scripts.fr.html
@@ -1,0 +1,1387 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="utf-8">
+<title>Les langues qui s’écrivent de droite à gauche</title>
+<meta name="description" content="Quelles langues peuvent s’écrire à l’aide d’écritures de droite à gauche ? Que faire lorsqu’une langue peut s’écrire à l’aide de plusieurs écritures ?">
+<script>
+var f = { }
+
+// AUTHORS should fill in these assignments:
+f.directory = 'questions'+'/' // the path to this file, not including /International or the file name
+f.filename = 'qa-scripts' // the file name WITHOUT extensions
+f.authors = 'Tex Texin, XenCraft' // author(s) and affiliations
+f.previousauthors = '' // as above
+f.modifiers = 'Richard Ishida, W3C' // people making substantive changes, and their affiliation
+f.searchString = 'qa-scripts' // blog search string - usually the filename without extensions
+f.firstPubDate = '2003-09-12' // date of the first publication of the document (after review)
+f.lastSubstUpdate = { date:'2022-06-15', time:'15:10'}  // date and time of latest substantive changes to this document
+f.status = 'published'  // should be one of draft, review, published, notreviewed or obsolete
+f.path = '../' // what you need to prepend to a URL to get to the /International directory 
+
+// AUTHORS AND TRANSLATORS should fill in these assignments:
+f.thisVersion = { date:'2023-07-15', time:'12:30'} // date and time of latest edits to this document/translation
+f.contributors = '' // people providing useful contributions or feedback during review or at other times
+// also make sure that the lang attribute on the html tag is correct!
+f.sources = '' // describes sources of information
+
+// TRANSLATORS should fill in these assignments:
+f.translators = 'Gwendoline Clavé, <a href="https://www.clavoline-traduction.fr/" rel="nofollow">Clavoline Traduction</a>' // translator(s) and their affiliation - a elements allowed, but use double quotes for attributes
+
+f.breadcrumb = 'characters'
+
+f.additionalLinks = ''
+</script>
+<script src="qa-scripts-data/translations.js"> </script>
+<script src="../javascript/doc-structure/article-dt.js"> </script>
+<script src="../javascript/boilerplate-text/boilerplate-fr.js"> </script>
+<!--TRANSLATORS must change -en in the line just above to the subtag for their language! -->
+<script src="../javascript/doc-structure/article-2022.js"> </script>
+<script src="../javascript/articletoc-2022.js"></script>
+<link rel="stylesheet" href="../style/article-2022.css">
+<link rel="copyright" href="#copyright">
+</head>
+
+<body>
+<header>
+<nav id="mainNavigation"></nav><script>document.getElementById('mainNavigation').innerHTML = mainNavigation</script>
+
+<h1>Les langues qui s’écrivent de droite à gauche</h1>
+</header>
+
+
+
+
+
+<div id="audience">
+<div id="updateInfo"></div><script>document.getElementById('updateInfo').innerHTML = g.updated</script>
+</div>
+
+
+
+
+
+
+
+<section id="question">
+<h2>Question</h2>
+
+<p class="question">Quelles langues s’écrivent de droite à gauche ?</p>
+
+<p>Le sens dans lequel s’écrit une langue (appelé directionnalité) dépend de l’<a href="#what" title="Qu’est-ce qu’une écriture ?">écriture</a> ou des écritures à utiliser.</p>
+
+<p>Avant de concevoir un site web ou de créer du contenu, il est essentiel de connaitre la directionnalité du texte, car celle-ci affecte l’organisation et la disposition des pages. En particulier, un texte qui s’écrit <span class="nobrk">de droite à gauche</span> présente des difficultés supplémentaires pour les personnes qui débutent. C’est donc une information importante pour bien estimer le travail nécessaire avant de créer des pages web dans une nouvelle langue.</p>
+</section>
+
+
+
+
+
+
+<section id="answer">
+<h2>Réponse</h2>
+
+
+
+<section id="what">
+<h3>Qu’est-ce qu’une écriture ?</h3>
+
+<p>La <a href="http://hapax.qc.ca/glossaire.htm#ecriture">version française</a> du <a class="print" href="https://www.unicode.org/glossary/">glossaire du Consortium Unicode</a> propose la définition suivante :</p>
+
+<blockquote>Écriture : ensemble de symboles utilisés pour représenter des informations textuelles d’un ou plusieurs systèmes d’écriture.</blockquote>
+
+<p>Au moment de la rédaction de cet article, Microsoft proposait une autre définition sur son <a class="print" href="https://msdn.microsoft.com/en-us/goglobal/bb964658#s">site international</a>, dont voici une traduction libre :</p>
+
+<blockquote>Écriture : ensemble de caractères destinés à afficher du texte et réunis par un point commun, lequel justifie qu’ils soient considérés comme un ensemble distinct.</blockquote>
+<blockquote>Une écriture peut servir à noter plusieurs langues. Par exemple, l’écriture latine permet de représenter toutes les langues d’Europe occidentale.</blockquote>
+<blockquote>De la même façon, une langue peut s’écrire à l’aide de plusieurs écritures ; pour certaines langues, c’est même une nécessité. C’est notamment le cas du japonais, qui compte au moins trois écritures : les syllabaires hiragana et katakana ainsi que les kanjis issus des caractères chinois.</blockquote>
+<blockquote>Dans ce sens, « écriture » se traduit par « script » en anglais ; il n’a pourtant aucun rapport avec les langages de script au sens informatique, comme Perl ou Visual Basic Scripting Edition (VBScript).</blockquote>
+</section>
+
+
+
+
+
+
+
+
+<section id="which">
+<h3>Quelles langues s’écrivent de droite à gauche ?</h3>
+
+<p>Les langues n’ont pas de direction ; ce sont les écritures qui en ont une. Une langue s’écrit donc dans la direction de l’écriture utilisée pour la noter.</p>
+
+<p>Une langue peut même s’écrire dans des directions différentes selon l’écriture utilisée. Ainsi, on peut noter l’azéri (aussi appelé azerbaïdjanais) à l’aide de l’écriture latine, cyrillique ou arabe. Avec l’écriture latine ou cyrillique, l’azéri s’écrit de gauche à droite. Avec l’écriture arabe, il s’écrit de droite à gauche.</p>
+</section>
+
+
+
+
+
+
+
+
+<section id="directions">
+<h3>Quelles langues peuvent s’écrire à l’aide d’écritures de droite à gauche ?</h3>
+
+<p>Le tableau suivant donne un aperçu des langues parlées modernes qui peuvent s’écrire à l’aide d’écritures de droite à gauche. Il indique également dans quels pays on les parle. Certaines langues moins parlées ne sont pas mentionnées. Ces données sont issues de la base de données <a href="https://www.ethnologue.com">Ethnologue</a> de SIL International.</p>
+
+<ul>
+<li>La colonne <samp>Écritures utilisées</samp> indique toutes les écritures qui peuvent servir à noter la langue concernée. L’ordre relatif donne une vague idée de la fréquence d’utilisation. Lorsqu’une écriture est peu utilisée, elle est indiquée entre parenthèses.</li>
+<li>La colonne <samp>Locuteurs potentiels</samp> indique le nombre de locuteurs et locutrices de la langue concernée (qu’il s’agisse de leur première ou de leur seconde langue). Ces chiffres ne tiennent pas compte des personnes qui n’utilisent ces langues que dans un cadre religieux.</li>
+</ul>
+
+<p>Le nombre de locuteurs et locutrices est une surestimation, car il ne tient pas compte du degré d’alphabétisation, des écritures concurrentes ou des tendances d’utilisation. Néanmoins, si on additionne les chiffres du tableau, on arrive à un total de 2 305 048 719. Le nombre réel de locuteurs et locutrices dépasse donc probablement le milliard.</p>
+
+<p>Ce tableau liste 12 écritures et 215 langues. Très largement utilisée, l’écriture arabe permet d’écrire 189 langues, qui comptent ensemble plus de deux milliards de locuteurs potentiels. Aucune distinction n’est faite entre les différents styles de l’écriture arabe, comme le nastaliq, le maghribi et le kano, ou entre les alphabets consonantiques (abjads) et les autres types d’alphabet. Comme nous l’avons vu plus haut, le nombre de personnes qui utilisent l’arabe en raison de leur religion n’est pas non plus pris en compte.</p>
+
+
+<table class="inband" id="table2">
+<tbody>
+<tr>
+<th>Écriture</th>
+<th>Langue</th>
+<th>Pays ou régions</th>
+<th>Écritures utilisées</th>
+<th>Locuteurs potentiels</th>
+</tr>
+<tr>
+<td rowspan="2">Adlam</td>
+<td>Peul [ful]</td>
+<td>Guinée, Mali, Nigéria, Niger, Tchad</td>
+<td>Latin, adlam</td>
+<td>35 337 640</td>
+</tr>
+<tr>
+<td>Pular [fuf]</td>
+<td>Guinée, Mali</td>
+<td>Latin, adlam</td>
+<td>4 778 200</td>
+</tr>
+
+
+
+<tr>
+<td rowspan="187">Arabe</td>
+<td>Peul de l’Adamaoua [fub]</td>
+<td>Cameroun</td>
+<td>Arabe</td>
+<td>5 685 500</td></tr>
+<tr>
+<td>Adyguéen ou circassien [ady]</td>
+<td>Russie</td>
+<td>Cyrillique, (arabe)</td>
+<td>605 400</td></tr>
+<tr>
+<td>Arabe algérien [arq]</td>
+<td> Algérie, Maroc, Tunisie, Sahara occidental</td>
+<td>Arabe</td>
+<td>40 259 600</td></tr>
+<tr>
+<td>Andaandi [dgl]</td>
+<td>Soudan</td>
+<td>Arabe</td>
+<td>70 000</td></tr>
+<tr>
+<td>Ashtiani [atn]</td>
+<td>Iran</td>
+<td>Arabe</td>
+<td>26 400</td></tr>
+<tr>
+<td>Azerbaïdjanais ou azéri [aze] (azj, azb)</td>
+<td>Azerbaïdjan, Iran</td>
+<td>Arabe, latin</td>
+<td>23 849 330</td></tr>
+<tr>
+<td>Arabe bahrani [abv]</td>
+<td>Bahreïn</td>
+<td>Arabe</td>
+<td>727 900</td></tr>
+<tr>
+<td>Bakhtiari [bqi]</td>
+<td>Iran</td>
+<td>Arabe</td>
+<td>1 240 000</td></tr>
+<tr>
+<td>Balangingi sama [sse]</td>
+<td>Philippines</td>
+<td>Arabe</td>
+<td>85 000</td></tr>
+<tr>
+<td>Balti [bft]</td>
+<td>Pakistan</td>
+<td>Arabe</td>
+<td>438 800</td></tr>
+<tr>
+<td>Banjar [bjn]</td>
+<td>Indonésie</td>
+<td>Arabe</td>
+<td>3 655 000</td></tr>
+<tr>
+<td>Bedja [bej]</td>
+<td>Soudan</td>
+<td>Arabe, latin</td>
+<td>2 498 000</td></tr>
+<tr>
+<td>Bhadrawahi [bhd]</td>
+<td>Inde</td>
+<td>Arabe, devanagari</td>
+<td>116 000</td></tr>
+<tr>
+<td>Brahoui [brh]</td>
+<td>Pakistan, Afghanistan</td>
+<td>Arabe</td>
+<td>2 864 400</td></tr>
+<tr>
+<td>Malais du Brunei [kxd]</td>
+<td>Brunei, Malaisie</td>
+<td>Arabe, latin</td>
+<td>321 000</td></tr>
+<tr>
+<td>Bourouchaski [bsk]</td>
+<td>Pakistan, Inde</td>
+<td>Arabe</td>
+<td>126 300</td></tr>
+<tr>
+<td>Tamazight du Maroc central [tzm]</td>
+<td>Maroc</td>
+<td>Arabe, tifinagh</td>
+<td>4 740 000</td></tr>
+<tr>
+<td>Kanouri central [knc]</td>
+<td>Nigéria</td>
+<td>Latin, arabe</td>
+<td>8 825 500</td></tr>
+<tr>
+<td>Sorani [ckb]</td>
+<td>Irak</td>
+<td>Arabe</td>
+<td>5 266 050</td></tr>
+<tr>
+<td>Pachto central [pst]</td>
+<td>Pakistan</td>
+<td>Arabe</td>
+<td>8 490 000</td></tr>
+<tr>
+<td>Arabe tchadien [shu]</td>
+<td>Tchad</td>
+<td>Arabe, latin</td>
+<td>2 061 220 </td></tr>
+<tr>
+<td>Chittagonien [ctg]</td>
+<td>Bangladesh</td>
+<td>Bengali, arabe</td>
+<td>13 000 000</td></tr>
+<tr>
+<td>Copte [cop]</td>
+<td>Égypte</td>
+<td>Copte, arabe</td>
+<td>0 (liturgique)</td></tr>
+<tr>
+<td>Arabe chypriote maronite [acy]</td>
+<td>Chypre</td>
+<td>Latin, (arabe)</td>
+<td>9 760</td></tr>
+<tr>
+<td>Dameli [dml]</td>
+<td>Pakistan</td>
+<td>Arabe</td>
+<td>5 000</td></tr>
+<tr>
+<td>Dari [prs]</td>
+<td>Afghanistan, Pakistan</td>
+<td>Arabe</td>
+<td>29 452 210</td></tr>
+<tr>
+<td>Deccan [dcc]</td>
+<td>Inde</td>
+<td>Arabe, (devanagari)</td>
+<td>12 800 000</td></tr>
+<tr>
+<td>Dezfuli [def]</td>
+<td>Iran</td>
+<td>Arabe</td>
+<td>Très peu</td></tr>
+<tr>
+<td>Dhatki [mki]</td>
+<td>Pakistan</td>
+<td>Arabe</td>
+<td>206 400</td></tr>
+<tr>
+<td>Dogri [dgo]</td>
+<td>Inde</td>
+<td>Devanagari, (arabe)</td>
+<td>2 600 000</td></tr>
+<tr>
+<td>Dongxiang [sce]</td>
+<td>Chine</td>
+<td>Arabe</td>
+<td>200 000</td></tr>
+<tr>
+<td>Dioula [dyu]</td>
+<td>Côte d’Ivoire</td>
+<td>Arabe, latin, n’ko</td>
+<td>12 504 000</td></tr>
+<tr>
+<td>Baloutchi oriental [bgp]</td>
+<td>Inde, Pakistan</td>
+<td>Arabe</td>
+<td>2 930 800</td></tr>
+<tr>
+<td>Cham oriental [cjm]</td>
+<td>Viêt Nam</td>
+<td>Cham, (arabe)</td>
+<td>132 000</td></tr>
+<tr>
+<td>Arabe bedawi [avl]</td>
+<td>Égypte, Libye</td>
+<td>Arabe</td>
+<td>2 430 300</td></tr>
+<tr>
+<td>Malinké de l’Est [emk]</td>
+<td>Guinée</td>
+<td>Arabe, latin, n’ko</td>
+<td>3 722 300</td></tr>
+<tr>
+<td>Arabe égyptien [arz]</td>
+<td>Égypte, (nombreux médias)</td>
+<td>Arabe</td>
+<td>74 826 320</td></tr>
+<tr>
+<td>Gazi [gzi]</td>
+<td>Iran</td>
+<td>Arabe</td>
+<td>7 030</td></tr>
+<tr>
+<td>Guilaki [glk]</td>
+<td>Iran</td>
+<td>Arabe</td>
+<td>2 490 000</td></tr>
+<tr>
+<td>Goaria [gig]</td>
+<td>Pakistan</td>
+<td>Arabe</td>
+<td>25 400</td></tr>
+<tr>
+<td>Gowro [gwf]</td>
+<td>Pakistan</td>
+<td>Arabe</td>
+<td>1 000</td></tr>
+<tr>
+<td>Goujari [gju]</td>
+<td>Inde</td>
+<td>Arabe, (devanagari)</td>
+<td>1 696 000</td></tr>
+<tr>
+<td>Arabe du Golfe [afb]</td>
+<td>Koweït et pays environnants</td>
+<td>Arabe</td>
+<td>10 656 700</td></tr>
+<tr>
+<td>Gurani [hac]</td>
+<td>Iran</td>
+<td>Arabe</td>
+<td>300 000</td></tr>
+<tr>
+<td>Gurgula [ggg]</td>
+<td>Pakistan</td>
+<td>Arabe</td>
+<td>35 300</td></tr>
+<tr>
+<td>Harzani [hrz]</td>
+<td>Iran</td>
+<td>Arabe</td>
+<td>34 900</td></tr>
+<tr>
+<td>Hassanya [mey]</td>
+<td>Mauritanie et pays environnants</td>
+<td>Arabe</td>
+<td>4 883 500</td></tr>
+<tr>
+<td>Haoussa [hau]</td>
+<td>Nigéria et Sahel</td>
+<td>Latin, arabe</td>
+<td>77 063 700</td></tr>
+<tr>
+<td>Hazara [haz]</td>
+<td>Afghanistan, Pakistan</td>
+<td>Arabe</td>
+<td>3 628 900</td></tr>
+<tr>
+<td>Arabe hijazi [acw]</td>
+<td>Arabie saoudite</td>
+<td>Arabe</td>
+<td>10 792 400</td></tr>
+<tr>
+<td>Ida’an [dbj]</td>
+<td>Malaisie</td>
+<td>Latin, (arabe)</td>
+<td>10 000</td></tr>
+<tr>
+<td>Indonésien [ind]</td>
+<td>Indonésie</td>
+<td>Latin, (arabe)</td>
+<td>198 000 000</td></tr>
+<tr>
+<td>Kohistani de l’Indus [mvy]</td>
+<td>Pakistan</td>
+<td>Arabe</td>
+<td>200 000</td></tr>
+<tr>
+<td>Ingouche [inh]</td>
+<td>Russie</td>
+<td>Cyrillique, (arabe)</td>
+<td>306 000</td></tr>
+<tr>
+<td>Persan iranien [pes]</td>
+<td>Iran</td>
+<td>Arabe</td>
+<td>77 377 510</td></tr>
+<tr>
+<td>Jadgali [jdg]</td>
+<td>Pakistan</td>
+<td>Arabe</td>
+<td>25 600</td></tr>
+<tr>
+<td>Diakhanké [jad]</td>
+<td>Guinée</td>
+<td>Arabe</td>
+<td>137 500</td></tr>
+<tr>
+<td>Bozo-jenaama [bze]</td>
+<td>Mali</td>
+<td>Arabe, latin</td>
+<td>197 000</td></tr>
+<tr>
+<td>Diola-fogny [dyo]</td>
+<td>Sénégal</td>
+<td>Arabe, latin</td>
+<td>457 000</td></tr>
+<tr>
+<td>Kachi koli [gjk]</td>
+<td>Pakistan, Inde</td>
+<td>Arabe, (gujarati)</td>
+<td>530 000</td></tr>
+<tr>
+<td>Kohistani de Kalam [gwc]</td>
+<td>Pakistan</td>
+<td>Arabe</td>
+<td>96 400</td></tr>
+<tr>
+<td>Kalasha [kls]</td>
+<td>Pakistan</td>
+<td>Arabe</td>
+<td>5 000</td></tr>
+<tr>
+<td>Cachemiri ou kashmiri [kas]</td>
+<td>Inde</td>
+<td>Arabe, (devanagari)</td>
+<td>7 132 780</td></tr>
+<tr>
+<td>Kati [bsh]</td>
+<td>Afghanistan</td>
+<td>Arabe</td>
+<td>135 800</td></tr>
+<tr>
+<td>Kazakh [kaz]</td>
+<td>Kazakhstan et pays environnants, Chine, Iran</td>
+<td>Cyrillique, arabe</td>
+<td>12 695 140</td></tr>
+<tr>
+<td>Mattokki [xnz]</td>
+<td>Égypte, Libye</td>
+<td>Arabe, copte, latin</td>
+<td>50 000</td></tr>
+<tr>
+<td>Turc du Khorassan [kmz]</td>
+<td>Iran</td>
+<td>Arabe</td>
+<td>936 000</td></tr>
+<tr>
+<td>Khowar [khw]</td>
+<td>Pakistan</td>
+<td>Arabe</td>
+<td>379 100</td></tr>
+<tr>
+<td>Khunsari [kfm]</td>
+<td>Iran</td>
+<td>Arabe</td>
+<td>26 400</td></tr>
+<tr>
+<td>Shina Kohistani [plk]</td>
+<td>Pakistan</td>
+<td>Arabe</td>
+<td>458 000</td></tr>
+<tr>
+<td>Koti [eko]</td>
+<td>Mozambique</td>
+<td>Latin, arabe</td>
+<td>140 000</td></tr>
+<tr>
+<td>Koumyk [kum]</td>
+<td>Russie</td>
+<td>Cyrillique, latin, (arabe)</td>
+<td>427 600</td></tr>
+<tr>
+<td>Kirghize ou kirghiz [kir]</td>
+<td>Kirghizistan et pays environnants</td>
+<td>Cyrillique, latin, arabe</td>
+<td>5 132 100</td></tr>
+<tr>
+<td>Laki [lki]</td>
+<td>Iran</td>
+<td>Arabe</td>
+<td>1 240 000</td></tr>
+<tr>
+<td>Lari [lrl]</td>
+<td>Iran</td>
+<td>Arabe</td>
+<td>118 000</td></tr>
+<tr>
+<td>Lasgerdi [lsa]</td>
+<td>Iran</td>
+<td>Arabe</td>
+<td>1 000</td></tr>
+<tr>
+<td>Arabe libyen [ayl]</td>
+<td>Libye, Égypte, Niger</td>
+<td>Arabe</td>
+<td>5 343 050</td></tr>
+<tr>
+<td>Peul du Macina [ffm]</td>
+<td>Mali et pays adjacents</td>
+<td>Latin, arabe</td>
+<td>1 523 240</td></tr>
+<tr>
+<td>Maba (Tchad) [mde]</td>
+<td>Tchad</td>
+<td>Latin, arabe</td>
+<td>567 000</td></tr>
+<tr>
+<td>Malais (langue individuelle) [zlm]</td>
+<td>Malaisie, Indonésie</td>
+<td>Latin, arabe</td>
+<td>19 185 470</td></tr>
+<tr>
+<td>Malayalam [mal]</td>
+<td>Inde</td>
+<td>Malayalam, (arabe)</td>
+<td>37 212 270</td></tr>
+<tr>
+<td>Mandinka [mnk]</td>
+<td>Sénégal, Guinée, Gambie</td>
+<td>Latin, arabe</td>
+<td>1 949 000</td></tr>
+<tr>
+<td>Kanouri manga [kby]</td>
+<td>Niger, Nigéria</td>
+<td>Latin, arabe</td>
+<td>480 000</td></tr>
+<tr>
+<td>Mahorais [swb]</td>
+<td>Mayotte</td>
+<td>Latin, arabe</td>
+<td>185 500</td></tr>
+<tr>
+<td>Marwari pakistanais [mve]</td>
+<td>Pakistan</td>
+<td>Arabe</td>
+<td>164 000</td></tr>
+<tr>
+<td>Mazandarani [mzn]</td>
+<td>Iran</td>
+<td>Arabe</td>
+<td>2 320 000</td></tr>
+<tr>
+<td>Arabe mésopotamien [acm]</td>
+<td>Irak et pays voisins</td>
+<td>Arabe</td>
+<td>19 063 530</td></tr>
+<tr>
+<td>Mogofin [mfg]</td>
+<td>Guinée</td>
+<td>Latin, (arabe)</td>
+<td>24 800</td></tr>
+<tr>
+<td>Arabe marocain [ary]</td>
+<td>Maroc, Tunisie, Algérie, Sahara occidental</td>
+<td>Arabe</td>
+<td>33 358 230</td></tr>
+<tr>
+<td>Munji [mnj]</td>
+<td>Afghanistan</td>
+<td>Arabe</td>
+<td>5 300</td></tr>
+<tr>
+<td>Mwani [wmw]</td>
+<td>Mozambique</td>
+<td>Arabe, latin</td>
+<td>166 000</td></tr>
+<tr>
+<td>Nafusi [jbn]</td>
+<td>Libye</td>
+<td>Arabe</td>
+<td>297 000</td></tr>
+<tr>
+<td>Arabe najdi [ars]</td>
+<td>Arabie saoudite et pays voisins</td>
+<td>Arabe</td>
+<td>18 153 010</td></tr>
+<tr>
+<td>Natanzi [ntz]</td>
+<td>Iran</td>
+<td>Arabe</td>
+<td>7 030</td></tr>
+<tr>
+<td>Biyabuneki [nyq]</td>
+<td>Iran</td>
+<td>Arabe</td>
+<td>7 030</td></tr>
+<tr>
+<td>Comorien anjouanais [wni]</td>
+<td>Comores</td>
+<td>Arabe, latin</td>
+<td>361 000</td></tr>
+<tr>
+<td>Grand-comorien [zdj]</td>
+<td>Comores</td>
+<td>Arabe, latin</td>
+<td>412 000</td></tr>
+<tr>
+<td>Peul du Nigéria [fuv]</td>
+<td>Nigéria, Cameroun</td>
+<td>Arabe, latin</td>
+<td>16 585 000</td></tr>
+<tr>
+<td>Nobiin [fia]</td>
+<td>Soudan, Égypte</td>
+<td>Arabe, latin, copte</td>
+<td>546 000</td></tr>
+<tr>
+<td>Azéri du Nord [azj]</td>
+<td>Azerbaïdjan, Géorgie</td>
+<td>Latin, (cyrillique, arabe)</td>
+<td>9 220 620</td></tr>
+<tr>
+<td>Arabe levantin septentrional [apc]</td>
+<td>Syrie</td>
+<td>Arabe</td>
+<td>31 437 480</td></tr>
+<tr>
+<td>Arabe mésopotamien septentrional [ayp]</td>
+<td>Irak</td>
+<td>Arabe</td>
+<td>10 252 460</td></tr>
+<tr>
+<td>Hindko du Nord [hno]</td>
+<td>Pakistan</td>
+<td>Arabe</td>
+<td>3 570 000</td></tr>
+<tr>
+<td>Kurmandji [kmr]</td>
+<td>Turquie et plusieurs pays d’Asie de l’Ouest</td>
+<td>Arabe, latin, (arménien, cyrillique)</td>
+<td>15 703 920</td></tr>
+<tr>
+<td>Lori du Nord [lrc]</td>
+<td>Iran</td>
+<td>Arabe</td>
+<td>1 820 000</td></tr>
+<tr>
+<td>Pachto du Nord [pbu]</td>
+<td>Pakistan</td>
+<td>Arabe</td>
+<td>30 172 800</td></tr>
+<tr>
+<td>Ouzbek du Nord [uzn]</td>
+<td>Ouzbékistan et pays voisins, Chine</td>
+<td>Latin, arabe, (cyrillique)</td>
+<td>27 745 270</td></tr>
+<tr>
+<td>Od [odk]</td>
+<td>Inde</td>
+<td>Arabe</td>
+<td>2 076 100</td></tr>
+<tr>
+<td>Arabe omanais [acx]</td>
+<td>Oman</td>
+<td>Arabe</td>
+<td>2 877 200</td></tr>
+<tr>
+<td>Ormuri [oru]</td>
+<td>Pakistan</td>
+<td>Arabe</td>
+<td>5 050</td></tr>
+<tr>
+<td>Pahari potwari [phr]</td>
+<td>Pakistan, Inde</td>
+<td>Arabe</td>
+<td>3 541 900</td></tr>
+<tr>
+<td>Phalura [phl]</td>
+<td>Pakistan</td>
+<td>Arabe</td>
+<td>14 400</td></tr>
+<tr>
+<td>Pendjabi [pan]</td>
+<td>Inde</td>
+<td>Gourmoukhî, arabe, (khojki)</td>
+<td>51 724 270</td></tr>
+<tr>
+<td>Parkari koli [kvx]</td>
+<td>Pakistan</td>
+<td>Arabe</td>
+<td>358 000</td></tr>
+<tr>
+<td>Parsi-dari [prd]</td>
+<td>Iran</td>
+<td>Arabe</td>
+<td>27 500</td></tr>
+<tr>
+<td>Yawi [mfa]</td>
+<td>Thaïlande</td>
+<td>Arabe, thaï</td>
+<td>1 470 000</td></tr>
+<tr>
+<td>Pulaar [fuc]</td>
+<td>Sénégal</td>
+<td>Latin, arabe</td>
+<td>5 398 700</td></tr>
+<tr>
+<td>Pular [fuf]</td>
+<td>Guinée, Mali</td>
+<td>Latin, arabe, adlam</td>
+<td>4 778 200</td></tr>
+<tr>
+<td>Puriki [prx]</td>
+<td>Inde</td>
+<td>Arabe, (tibétain)</td>
+<td>93 500</td></tr>
+<tr>
+<td>Kachkaï [qxq]</td>
+<td>Iran</td>
+<td>Arabe</td>
+<td>995 000</td></tr>
+<tr>
+<td>Rohingya [rhg]</td>
+<td>Birmanie, Bangladesh</td>
+<td>Arabe, hanifi</td>
+<td>2 529 250</td></tr>
+<tr>
+<td>Saafi [sav]</td>
+<td>Sénégal</td>
+<td>Arabe, latin</td>
+<td>200 000</td></tr>
+<tr>
+<td>Arabe saïdi [aec]</td>
+<td>Égypte, Libye</td>
+<td>Arabe</td>
+<td>24 100 000</td></tr>
+<tr>
+<td>Arabe sanaani [ayn]</td>
+<td>Yémen</td>
+<td>Arabe</td>
+<td>12 567 960</td></tr>
+<tr>
+<td>Sangsari [sgr]</td>
+<td>Iran</td>
+<td>Arabe</td>
+<td>42 300</td></tr>
+<tr>
+<td>Saraiki [skr]</td>
+<td>Pakistan</td>
+<td>Arabe, khojki</td>
+<td>26 219 000</td></tr>
+<tr>
+<td>Semnani [smy]</td>
+<td>Iran</td>
+<td>Arabe</td>
+<td>68 700</td></tr>
+<tr>
+<td>Sérère [srr]</td>
+<td>Sénégal</td>
+<td>Arabe, latin</td>
+<td>1 712 300</td></tr>
+<tr>
+<td>Shina [scl]</td>
+<td>Pakistan</td>
+<td>Arabe</td>
+<td>720 200</td></tr>
+<tr>
+<td>Shughni [sgh]</td>
+<td>Tadjikistan, Afghanistan</td>
+<td>Latin, cyrillique, arabe</td>
+<td>80 000</td></tr>
+<tr>
+<td>Sindhi [snd]</td>
+<td>Pakistan, Inde</td>
+<td>Arabe, (devanagari, gourmoukhî, khojki)</td>
+<td>33 217 150</td></tr>
+<tr>
+<td>Somali [som]</td>
+<td>Somalie et pays voisins</td>
+<td>Latin, arabe</td>
+<td>21 930 230</td></tr>
+<tr>
+<td>Soninké [snk]</td>
+<td>Mali et pays voisins</td>
+<td>Latin, arabe</td>
+<td>2 189 250</td></tr>
+<tr>
+<td>Soqotri [sqt]</td>
+<td>Yémen</td>
+<td>Latin, arabe</td>
+<td>111 000</td></tr>
+<tr>
+<td>Azéri du sud [azb]</td>
+<td>Iran et pays voisins</td>
+<td>Arabe</td>
+<td>14 629 370</td></tr>
+<tr>
+<td>Arabe levantin méridional [ajp]</td>
+<td>Jordanie, Syrie</td>
+<td>Arabe</td>
+<td>12 711 300</td></tr>
+<tr>
+<td>Pashai du Sud-Est [psi]</td>
+<td>Afghanistan</td>
+<td>Arabe</td>
+<td>366 000</td></tr>
+<tr>
+<td>Baloutchi du Sud [bcc]</td>
+<td>Pakistan</td>
+<td>Arabe</td>
+<td>3 555 700</td></tr>
+<tr>
+<td>Hindko du Sud [hnd]</td>
+<td>Pakistan</td>
+<td>Arabe</td>
+<td>1 170 000</td></tr>
+<tr>
+<td>Kurde du Sud [sdh]</td>
+<td>Iran</td>
+<td>Arabe</td>
+<td>3 730 000</td></tr>
+<tr>
+<td>Lori du Sud [luz]</td>
+<td>Iran</td>
+<td>Arabe</td>
+<td>1 140 000</td></tr>
+<tr>
+<td>Pachto du Sud [pbt]</td>
+<td>Afghanistan</td>
+<td>Arabe</td>
+<td>19 732 400</td></tr>
+<tr>
+<td>Ouzbek du Sud [uzs]</td>
+<td>Afghanistan</td>
+<td>Arabe</td>
+<td>5 296 100</td></tr>
+<tr>
+<td>Dialectes du sud-ouest du Fars [fay]</td>
+<td>Iran</td>
+<td>Arabe</td>
+<td>110 000</td></tr>
+<tr>
+<td>Arabe standard moderne [arb]</td>
+<td>Très répandu</td>
+<td>Arabe</td>
+<td>273 989 700</td></tr>
+<tr>
+<td>Malaisien [zsm]</td>
+<td>Malaisie</td>
+<td>Latin, arabe</td>
+<td>(liturgique)</td></tr>
+<tr>
+<td>Arabe soudanais [apd]</td>
+<td>Soudan</td>
+<td>Arabe, latin</td>
+<td>42 332 360</td></tr>
+<tr>
+<td>Soundanais [sun]</td>
+<td>Indonésie</td>
+<td>Latin, (arabe, javanais)</td>
+<td>36 700 000</td></tr>
+<tr>
+<td>Soso, soussou ou susu [sus]</td>
+<td>Guinée</td>
+<td>Latin, arabe</td>
+<td>2 434 140</td></tr>
+<tr>
+<td>Swahili [swh]</td>
+<td>Tanzanie et pays voisins</td>
+<td>Latin, (arabe)</td>
+<td>71 416 500</td></tr>
+<tr>
+<td>Arabe ta’izzi-adeni [acq]</td>
+<td>Yémen</td>
+<td>Arabe</td>
+<td>11 821 100</td></tr>
+<tr>
+<td>Chaoui [shy]</td>
+<td>Algérie</td>
+<td>Arabe, tifinagh</td>
+<td>2 300 000</td></tr>
+<tr>
+<td>Chleuh [shi]</td>
+<td>Maroc</td>
+<td>Tifinagh, arabe</td>
+<td> 5 118 000</td></tr>
+<tr>
+<td>Tadaksahak [dsq]</td>
+<td>Mali</td>
+<td>Arabe, latin</td>
+<td>159 800</td></tr>
+<tr>
+<td>Tagdal [tda]</td>
+<td>Niger</td>
+<td>Latin, arabe, tifinagh</td>
+<td>60 600</td></tr>
+<tr>
+<td>Tamahaq tahaggart [thv]</td>
+<td>Algérie</td>
+<td>Latin, arabe, tifinagh</td>
+<td>114 200</td></tr>
+<tr>
+<td>Tadjik [tgk]</td>
+<td>Tadjikistan</td>
+<td>Latin, (cyrillique, arabe)</td>
+<td>8 195 120</td></tr>
+<tr>
+<td>Arabe tadjik [abh]</td>
+<td>Tadjikistan</td>
+<td>Arabe</td>
+<td>17 300</td></tr>
+<tr>
+<td>Takestani [tks]</td>
+<td>Iran</td>
+<td>Arabe</td>
+<td>395 000</td></tr>
+<tr>
+<td>Talysh [tly]</td>
+<td>Azerbaïdjan</td>
+<td>Latin, arabe, cyrillique</td>
+<td>226 100</td></tr>
+<tr>
+<td>Rifain [rif]</td>
+<td>Maroc</td>
+<td>Latin, arabe, tifinagh</td>
+<td>4 399 000</td></tr>
+<tr>
+<td>Tausug [tsg]</td>
+<td>Philippines</td>
+<td>Latin, arabe</td>
+<td>946 000</td></tr>
+<tr>
+<td>Tawellemmet [ttq]</td>
+<td>Niger, Mali</td>
+<td>Latin, arabe, tifinagh</td>
+<td>870 000</td></tr>
+<tr>
+<td>Tem [kdh]</td>
+<td>Togo et pays voisins</td>
+<td>Latin, arabe</td>
+<td>390 200</td></tr>
+<tr>
+<td>Bozo-tiéyaxo [boz]</td>
+<td>Mali</td>
+<td>Latin, arabe</td>
+<td>118 000</td></tr>
+<tr>
+<td>Torwali [trw]</td>
+<td>Pakistan</td>
+<td>Arabe</td>
+<td>114 000</td></tr>
+<tr>
+<td>Mozabite [mzb]</td>
+<td>Algérie</td>
+<td>Latin, arabe, tifinagh</td>
+<td>150 000</td></tr>
+<tr>
+<td>Arabe tunisien [aeb]</td>
+<td>Tunisie</td>
+<td>Arabe</td>
+<td>11 709 020</td></tr>
+<tr>
+<td>Turc [tur]</td>
+<td>Turquie</td>
+<td>Latin, (arabe)</td>
+<td>88 098 480</td></tr>
+<tr>
+<td>Turkmène [tuk]</td>
+<td>Turkménistan, Afghanistan</td>
+<td>Latin, arabe, cyrillique</td>
+<td>6 656 060</td></tr>
+<tr>
+<td>Ourdou [urd]</td>
+<td>Pakistan</td>
+<td>Arabe</td>
+<td>231 295 440</td></tr>
+<tr>
+<td>Ouïghour [uig]</td>
+<td>Chine, Afghanistan</td>
+<td>Arabe</td>
+<td>10 411 822</td></tr>
+<tr>
+<td>Vafsi [vaf]</td>
+<td>Iran</td>
+<td>Arabe</td>
+<td>22 200</td></tr>
+<tr>
+<td>Wadiyara koli [kxp]</td>
+<td>Inde</td>
+<td>Gujarati, arabe</td>
+<td>583 000</td></tr>
+<tr>
+<td>Wakhi [wbl]</td>
+<td>Afghanistan</td>
+<td>Arabe, latin, cyrillique</td>
+<td>52 200</td></tr>
+<tr>
+<td>Baloutchi occidental [bgn]</td>
+<td>Pakistan, Turkménistan</td>
+<td>Arabe, cyrillique</td>
+<td>2 264 350</td></tr>
+<tr>
+<td>Cham occidental [cja]</td>
+<td>Cambodge</td>
+<td>Cham, arabe, latin</td>
+<td>312 500</td></tr>
+<tr>
+<td>Malinké de l’Ouest [mlq]</td>
+<td>Sénégal, Mali</td>
+<td>Latin, arabe</td>
+<td>2 067 260</td></tr>
+<tr>
+<td>Peul du Niger occidental [fuh]</td>
+<td>Niger et pays voisins</td>
+<td>Latin, arabe</td>
+<td>2 320 000</td></tr>
+<tr>
+<td>Pendjabi de l’Ouest [pnb]</td>
+<td>Pakistan</td>
+<td>Arabe, (khojki)</td>
+<td>66 441 240</td></tr>
+<tr>
+<td>Wolio [wlo]</td>
+<td>Indonésie</td>
+<td>Arabe</td>
+<td>65 000</td></tr>
+<tr>
+<td>Wolof [wol]</td>
+<td>Sénégal, Mauritanie</td>
+<td>Latin, (arabe)</td>
+<td>12 266 290</td></tr>
+<tr>
+<td>Yakan [yka]</td>
+<td>Philippines</td>
+<td>Latin, arabe</td>
+<td>130 000</td></tr>
+<tr>
+<td>Jalonké [yal]</td>
+<td>Guinée</td>
+<td>Latin, arabe</td>
+<td>180 700</td></tr>
+<tr>
+<td>Yidgha [ydg]</td>
+<td>Pakistan</td>
+<td>Arabe</td>
+<td>6 150</td></tr>
+<tr>
+<td>Yoruba [yor]</td>
+<td>Nigéria</td>
+<td>Latin, (arabe)</td>
+<td>45 612 560</td></tr>
+<tr>
+<td>Zarma [dje]</td>
+<td>Niger</td>
+<td>Latin, (arabe)</td>
+<td>4 330 100</td>
+</tr>
+
+
+
+
+<tr>
+<td>Hanifi</td>
+<td>Rohingya [rhg]</td>
+<td>Birmanie, Bangladesh</td>
+<td>Hanifi, arabe, latin</td>
+<td> 2 529 250</td>
+</tr>
+
+
+
+
+
+<tr>
+<td rowspan="8">Hébreu</td>
+<td>Boukhori [bhh]</td>
+<td>Israël</td>
+<td>Cyrillique (hébreu)</td>
+<td>117 840</td>
+</tr>
+<tr>
+<td>Yiddish oriental [ydd]</td>
+<td>Israël</td>
+<td>Hébreu</td>
+<td>371 657</td>
+</tr>
+<tr>
+<td>Hébreu [heb]</td>
+<td>Israël</td>
+<td>Hébreu</td>
+<td>9 387 050</td>
+</tr>
+<tr>
+<td>Hulaula [huy]</td>
+<td>Israël</td>
+<td>Hébreu</td>
+<td>350</td>
+</tr>
+<tr>
+<td>Arabe judéo-irakien [yhd]</td>
+<td>Israël</td>
+<td>Hébreu</td>
+<td>97 200</td>
+</tr>
+<tr>
+<td>Arabe judéo-marocain [aju]</td>
+<td>Maroc</td>
+<td>Hébreu</td>
+<td>65 910</td>
+</tr>
+<tr>
+<td>Judéo-persan [jpr]</td>
+<td>Israël</td>
+<td>Hébreu</td>
+<td>55 000</td>
+</tr>
+<tr>
+<td>Juhuri [jdt]</td>
+<td>Russie, Azerbaïdjan</td>
+<td>Cyrillique (hébreu, latin)</td>
+<td>81 500</td>
+</tr>
+
+
+
+
+
+<tr>
+<td>Mandéen</td>
+<td>Néo-mandéen [mid]</td>
+<td>Iran</td>
+<td>Mandéen</td>
+<td>23 000</td>
+</tr>
+
+
+
+
+
+<tr>
+<td>Kikakui ou mendé</td>
+<td>Mendé [men]</td>
+<td> Libéria, Sierra Leone</td>
+<td>Latin (kikakui)</td>
+<td>2 511 600</td>
+</tr>
+
+
+
+
+
+
+<tr>
+<td rowspan="5">N’ko </td>
+<td>Bambara [bam]</td>
+<td> Mali, Côte d’Ivoire</td>
+<td>Latin, n’ko</td>
+<td>14 183 340</td>
+</tr>
+<tr>
+<td>Dioula [dyu]</td>
+<td>Côte d’Ivoire</td>
+<td>Latin, n’ko, arabe</td>
+<td>12 504 000</td>
+</tr>
+<tr>
+<td>Malinké de l’Est [emk]</td>
+<td>Guinée, Mali</td>
+<td>Latin, n’ko, arabe</td>
+<td>3 722 300</td>
+</tr>
+<tr>
+<td>Mandinka [man]</td>
+<td>Guinée</td>
+<td>Latin, n’ko, arabe</td>
+<td>8 731 560</td>
+</tr>
+<tr>
+<td>N’ko [nqo] (koinè)</td>
+<td>Guinée, Mali, Côte d’Ivoire</td>
+<td>N’ko</td>
+<td>?</td>
+</tr>
+
+
+
+
+
+
+<tr>
+<td>Ancien hongrois</td>
+<td>Hongrois [hun]</td>
+<td>Hongrie</td>
+<td>Latin, (ancien hongrois)</td>
+<td>12 560 490</td>
+</tr>
+
+
+
+
+
+
+<tr>
+<td>Samaritain</td>
+<td>Araméen samaritain [sam]</td>
+<td>Israël, Palestine</td>
+<td>Hébreu, samaritain</td>
+<td>(liturgique)</td>
+</tr>
+
+
+
+
+
+
+
+<tr>
+<td rowspan="4">Syriaque</td>
+<td>Soureth [aii]</td>
+<td>Irak, Turquie, Syrie</td>
+<td>Cyrillique, syriaque</td>
+<td>594 050</td>
+</tr>
+<tr>
+<td>Néo-araméen chaldéen [cld]</td>
+<td>Irak</td>
+<td>Syriaque</td>
+<td>232 480</td>
+</tr>
+<tr>
+<td>Syriaque classique [syr]</td>
+<td>Turquie, Syrie</td>
+<td>Syriaque</td>
+<td>(liturgique)</td>
+</tr>
+<tr>
+<td>Touroyo [tru]</td>
+<td>Turquie, Syrie</td>
+<td>Latin (syriaque)</td>
+<td>103 100</td>
+</tr>
+
+
+
+
+
+<tr>
+<td>Thaana</td>
+<td>Maldivien [dv]</td>
+<td>Maldives</td>
+<td>Thaana, latin</td>
+<td>340 500</td>
+</tr>
+
+
+
+
+
+
+<tr>
+<td>Yézidi</td>
+<td>Kurmandji [kmr]</td>
+<td>Turquie, Irak, Iran, Syrie, Arménie</td>
+<td>Arabe, cyrillique, latin, (yézidi)</td>
+<td>15 703 920</td>
+</tr>
+
+</tbody>
+</table>
+
+
+
+
+<p>Ce tableau ne tient pas compte de l’utilisation historique des écritures. Par exemple, l’écriture arabe était autrefois utilisée dans l’ensemble de l’Empire ottoman et dans de nombreuses régions d’Asie centrale.</p>
+
+<p>Ce tableau ne mentionne pas non plus les écritures de droite à gauche qui ne sont plus utilisées pour la communication moderne, bien qu’elles soient toujours nécessaires à des universitaires et à des élèves à travers le monde. Il s’agit des écritures araméenne impériale, avestique, hatréenne, kharoshthi, lydienne, manichéenne, minoenne, nabatéenne, palmyrénienne, parthe, pehlevi et phénicienne.</p>
+</section>
+
+
+
+
+
+
+<section id="whichscript">
+<h3>Quelle écriture devrais-je utiliser ?</h3>
+
+<p><strong>Lors de la conception ou de la localisation d’un site web, si une langue peut s’écrire à l’aide de plusieurs écritures, faut-il afficher le texte dans toutes ces écritures ? Sinon, laquelle choisir ?</strong></p>
+
+<p>La réponse dépend de votre public cible. En effet, l’écriture peut être différente d’un pays ou d’une région à l’autre. Elle peut aussi changer en cas d’évolution de la loi ou de la politique gouvernementale. Reprenons l’exemple de l’azéri, qui peut s’écrire à l’aide de l’écriture latine, cyrillique ou arabe :</p>
+
+<ul>
+<li>Pour toucher les locuteurs et locutrices de l’azéri <strong>en Iran</strong>, vous devriez utiliser l’<strong>écriture arabe</strong>.</li>
+<li><strong>En Azerbaïdjan</strong>, l’<strong>écriture cyrillique</strong> était privilégiée depuis la fin des années 1930 et son utilisation est devenue obligatoire en 1940. Avec la chute de l’Union soviétique, à partir de 1991, l’utilisation de l’<strong>écriture latine</strong> s’est peu à peu imposée, jusqu’à devenir obligatoire pour les communications officielles en 2001. Cependant, pour toute communication non officielle, vous feriez mieux d’utiliser l’<strong>écriture cyrillique</strong> avec un public plus âgé et l’<strong>écriture latine</strong> avec un public plus jeune. Vous aurez donc besoin de <strong>ces deux écritures</strong> pour toucher l’ensemble de la population de l’Azerbaïdjan.</li>
+<li>Si vous souhaitez toucher <strong>l’ensemble des locuteurs et locutrices de l’azéri</strong>, vous devriez utiliser <strong>les trois écritures</strong>. Notez toutefois que les locuteurs et locutrices d’azéri ne s’expriment pas tout à fait de la même façon d’un pays à l’autre, tout comme les francophones qui vivent dans des pays différents. Par exemple, on peut constater des différences terminologiques entre les pays.</li>
+</ul>
+
+<p>Vous devriez aussi garder à l’esprit que votre choix d’écriture peut avoir des connotations politiques, religieuses, démographiques ou culturelles. En effet :</p>
+
+<ul>
+<li>Dans les pays où la langue des études supérieures est le russe, l’<strong>écriture cyrillique</strong> sera utilisée par les personnes éduquées.</li>
+<li>L’<strong>écriture latine</strong> est associée aux mouvements panturquistes et peut indiquer des mouvements qui se rapprochent de l’ouest.</li>
+<li>L’<strong>écriture arabe</strong> peut quant à elle évoquer les mouvements islamistes.</li>
+</ul>
+
+<p>Vous devriez donc faire des recherches pour identifier les langues nécessaires pour cibler différentes cultures et, de la même façon, mener l’enquête pour identifier l’écriture ou les écritures à privilégier selon votre situation. Vous trouverez des suggestions dans <a href="#directions">le tableau</a> ci-dessus.</p>
+</section>
+</section>
+
+
+
+
+
+<section id="endlinks">
+<h2>Pour aller plus loin</h2>
+<aside class="section" id="survey"> </aside><script>document.getElementById('survey').innerHTML = g.survey</script>
+
+<ul id="full-links">
+<li>
+<p>Liens connexes, <cite>Créer du contenu HTML et CSS</cite></p>
+<ul>
+<li><a href="/International/techniques/authoring-html#direction">Direction du texte</a></li>
+</ul>
+</li>
+<li>
+<p><a href="https://www.ethnologue.com/">SIL Ethnologue</a> : une bonne ressource pour obtenir des informations sur les langues.</p>
+</li>
+<!--li>
+<p><a href="http://www.ontopia.net/i18n/direction.jsp?id=rtl">Ontopia, Lars Marius Garshol's page on <span class="nobr">right-to-left</span> scripts</a></p>
+</li-->
+<li>
+<p><a href="https://www.omniglot.com/">Omniglot</a> : un guide sur les systèmes d’écriture.</p>
+</li>
+<li>
+<p><a href="https://www.rosettaproject.org/">Rosetta Project</a> : des descriptions, textes, analyses et fichiers audio concernant 1000 langues.</p>
+</li>
+<li>
+<p><a href="https://r12a.github.io/scripts/#scriptnotes">Orthography descriptions</a> : des fiches qui résument les principales caractéristiques d’une écriture ou d’une orthographe.</p>
+</li>
+</ul>
+</section>
+
+<footer id="thefooter"></footer><script>document.getElementById('thefooter').innerHTML = g.bottomOfPage</script>
+<script>completePage()</script>
+</body>
+</html>

--- a/questions/qa-scripts.fr.html
+++ b/questions/qa-scripts.fr.html
@@ -1364,19 +1364,19 @@ f.additionalLinks = ''
 </ul>
 </li>
 <li>
-<p><a href="https://www.ethnologue.com/">SIL Ethnologue</a> : une bonne ressource pour obtenir des informations sur les langues.</p>
+<p><a href="https://www.ethnologue.com/">SIL Ethnologue</a> (une bonne ressource pour obtenir des informations sur les langues)</p>
 </li>
 <!--li>
 <p><a href="http://www.ontopia.net/i18n/direction.jsp?id=rtl">Ontopia, Lars Marius Garshol's page on <span class="nobr">right-to-left</span> scripts</a></p>
 </li-->
 <li>
-<p><a href="https://www.omniglot.com/">Omniglot</a> : un guide sur les systèmes d’écriture.</p>
+<p><a href="https://www.omniglot.com/">Omniglot</a> (un guide sur les systèmes d’écriture)</p>
 </li>
 <li>
-<p><a href="https://www.rosettaproject.org/">Rosetta Project</a> : des descriptions, textes, analyses et fichiers audio concernant 1000 langues.</p>
+<p><a href="https://www.rosettaproject.org/">Rosetta Project</a> (des descriptions, textes, analyses et fichiers audio concernant 1000 langues)</p>
 </li>
 <li>
-<p><a href="https://r12a.github.io/scripts/#scriptnotes">Orthography descriptions</a> : des fiches qui résument les principales caractéristiques d’une écriture ou d’une orthographe.</p>
+<p><a href="https://r12a.github.io/scripts/#scriptnotes">Orthography descriptions</a> (des fiches qui résument les principales caractéristiques d’une écriture ou d’une orthographe)</p>
 </li>
 </ul>
 </section>

--- a/questions/qa-scripts.fr.html
+++ b/questions/qa-scripts.fr.html
@@ -132,7 +132,7 @@ f.additionalLinks = ''
 
 <p>Le nombre de locuteurs et locutrices est une surestimation, car il ne tient pas compte du degré d’alphabétisation, des écritures concurrentes ou des tendances d’utilisation. Néanmoins, si on additionne les chiffres du tableau, on arrive à un total de 2 305 048 719. Le nombre réel de locuteurs et locutrices dépasse donc probablement le milliard.</p>
 
-<p>Ce tableau liste 12 écritures et 215 langues. Très largement utilisée, l’écriture arabe permet d’écrire 189 langues, qui comptent ensemble plus de deux milliards de locuteurs potentiels. Aucune distinction n’est faite entre les différents styles de l’écriture arabe, comme le nastaliq, le maghribi et le kano, ou entre les alphabets consonantiques (abjads) et les autres types d’alphabet. Comme nous l’avons vu plus haut, le nombre de personnes qui utilisent l’arabe en raison de leur religion n’est pas non plus pris en compte.</p>
+<p>Ce tableau liste 12 écritures et 215 langues. Très largement utilisée, l’écriture arabe permet d’écrire 189 langues, qui comptent ensemble plus de deux milliards de locuteurs potentiels. Aucune distinction n’est faite entre les différents styles de l’écriture arabe, comme le nastaliq, le maghribi et le kano, ou entre les orthographes qui sont des <a class="termref" href="https://w3c.github.io/i18n-glossary/#dfn-abjad">abjads</a> (alphabets consonantiques) et celles qui sont des <a class="termref" href="https://w3c.github.io/i18n-glossary/#dfn-alphabet">alphabets</a>. Comme nous l’avons vu plus haut, le nombre de personnes qui utilisent l’arabe en raison de leur religion n’est pas non plus pris en compte.</p>
 
 
 <table class="inband" id="table2">
@@ -160,27 +160,145 @@ f.additionalLinks = ''
 
 
 
+
+
+
+<tr>
+<td>Ancien hongrois</td>
+<td>Hongrois [hun]</td>
+<td>Hongrie</td>
+<td>Latin, (ancien hongrois)</td>
+<td>12 560 490</td>
+</tr>
+
+
+
 <tr>
 <td rowspan="187">Arabe</td>
-<td>Peul de l’Adamaoua [fub]</td>
-<td>Cameroun</td>
-<td>Arabe</td>
-<td>5 685 500</td></tr>
-<tr>
 <td>Adyguéen ou circassien [ady]</td>
 <td>Russie</td>
 <td>Cyrillique, (arabe)</td>
 <td>605 400</td></tr>
 <tr>
-<td>Arabe algérien [arq]</td>
-<td> Algérie, Maroc, Tunisie, Sahara occidental</td>
-<td>Arabe</td>
-<td>40 259 600</td></tr>
-<tr>
 <td>Andaandi [dgl]</td>
 <td>Soudan</td>
 <td>Arabe</td>
 <td>70 000</td></tr>
+<tr>
+<td>Arabe algérien [arq]</td>
+<td>Algérie, Maroc, Tunisie, Sahara occidental</td>
+<td>Arabe</td>
+<td>40 259 600</td></tr>
+<tr>
+<td>Arabe bahrani [abv]</td>
+<td>Bahreïn</td>
+<td>Arabe</td>
+<td>727 900</td></tr>
+<tr>
+<td>Arabe bedawi [avl]</td>
+<td>Égypte, Libye</td>
+<td>Arabe</td>
+<td>2 430 300</td></tr>
+<tr>
+<td>Arabe chypriote maronite [acy]</td>
+<td>Chypre</td>
+<td>Latin, (arabe)</td>
+<td>9 760</td></tr>
+<tr>
+<td>Arabe du Golfe [afb]</td>
+<td>Koweït et pays environnants</td>
+<td>Arabe</td>
+<td>10 656 700</td></tr>
+<tr>
+<td>Arabe égyptien [arz]</td>
+<td>Égypte, (nombreux médias)</td>
+<td>Arabe</td>
+<td>74 826 320</td></tr>
+<tr>
+<td>Arabe hijazi [acw]</td>
+<td>Arabie saoudite</td>
+<td>Arabe</td>
+<td>10 792 400</td></tr>
+<tr>
+<td>Arabe levantin méridional [ajp]</td>
+<td>Jordanie, Syrie</td>
+<td>Arabe</td>
+<td>12 711 300</td></tr>
+<tr>
+<td>Arabe levantin septentrional [apc]</td>
+<td>Syrie</td>
+<td>Arabe</td>
+<td>31 437 480</td></tr>
+<tr>
+<td>Arabe libyen [ayl]</td>
+<td>Libye, Égypte, Niger</td>
+<td>Arabe</td>
+<td>5 343 050</td></tr>
+<tr>
+<td>Arabe marocain [ary]</td>
+<td>Maroc, Tunisie, Algérie, Sahara occidental</td>
+<td>Arabe</td>
+<td>33 358 230</td></tr>
+<tr>
+<td>Arabe mésopotamien [acm]</td>
+<td>Irak et pays voisins</td>
+<td>Arabe</td>
+<td>19 063 530</td></tr>
+<tr>
+<td>Arabe mésopotamien septentrional [ayp]</td>
+<td>Irak</td>
+<td>Arabe</td>
+<td>10 252 460</td></tr>
+<tr>
+<td>Arabe najdi [ars]</td>
+<td>Arabie saoudite et pays voisins</td>
+<td>Arabe</td>
+<td>18 153 010</td></tr>
+<tr>
+<td>Arabe omanais [acx]</td>
+<td>Oman</td>
+<td>Arabe</td>
+<td>2 877 200</td></tr>
+<tr>
+<td>Arabe saïdi [aec]</td>
+<td>Égypte, Libye</td>
+<td>Arabe</td>
+<td>24 100 000</td></tr>
+<tr>
+<td>Arabe sanaani [ayn]</td>
+<td>Yémen</td>
+<td>Arabe</td>
+<td>12 567 960</td></tr>
+<tr>
+<td>Arabe soudanais [apd]</td>
+<td>Soudan</td>
+<td>Arabe, latin</td>
+<td>42 332 360</td></tr>
+<tr>
+<td>Arabe standard moderne [arb]</td>
+<td>Très répandu</td>
+<td>Arabe</td>
+<td>273 989 700</td></tr>
+<tr>
+<td>Arabe ta’izzi-adeni [acq]</td>
+<td>Yémen</td>
+<td>Arabe</td>
+<td>11 821 100</td></tr>
+<tr>
+<td>Arabe tadjik [abh]</td>
+<td>Tadjikistan</td>
+<td>Arabe</td>
+<td>17 300</td></tr>
+<tr>
+<td>Arabe tchadien [shu]</td>
+<td>Tchad</td>
+<td>Arabe, latin</td>
+<td>2 061 220 </td></tr>
+<tr>
+<td>Arabe tunisien [aeb]</td>
+<td>Tunisie</td>
+<td>Arabe</td>
+<td>11 709 020</td></tr>
 <tr>
 <td>Ashtiani [atn]</td>
 <td>Iran</td>
@@ -189,13 +307,18 @@ f.additionalLinks = ''
 <tr>
 <td>Azerbaïdjanais ou azéri [aze] (azj, azb)</td>
 <td>Azerbaïdjan, Iran</td>
-<td>Arabe, latin</td>
+<td>Arabe, latin, (cyrillique)</td>
 <td>23 849 330</td></tr>
 <tr>
-<td>Arabe bahrani [abv]</td>
-<td>Bahreïn</td>
+<td>Azéri du Nord [azj]</td>
+<td>Azerbaïdjan, Géorgie</td>
+<td>Latin, (cyrillique, arabe)</td>
+<td>9 220 620</td></tr>
+<tr>
+<td>Azéri du sud [azb]</td>
+<td>Iran et pays voisins</td>
 <td>Arabe</td>
-<td>727 900</td></tr>
+<td>14 629 370</td></tr>
 <tr>
 <td>Bakhtiari [bqi]</td>
 <td>Iran</td>
@@ -206,6 +329,21 @@ f.additionalLinks = ''
 <td>Philippines</td>
 <td>Arabe</td>
 <td>85 000</td></tr>
+<tr>
+<td>Baloutchi du Sud [bcc]</td>
+<td>Pakistan</td>
+<td>Arabe</td>
+<td>3 555 700</td></tr>
+<tr>
+<td>Baloutchi occidental [bgn]</td>
+<td>Pakistan, Turkménistan</td>
+<td>Arabe, cyrillique</td>
+<td>2 264 350</td></tr>
+<tr>
+<td>Baloutchi oriental [bgp]</td>
+<td>Inde, Pakistan</td>
+<td>Arabe</td>
+<td>2 930 800</td></tr>
 <tr>
 <td>Balti [bft]</td>
 <td>Pakistan</td>
@@ -227,60 +365,70 @@ f.additionalLinks = ''
 <td>Arabe, devanagari</td>
 <td>116 000</td></tr>
 <tr>
-<td>Brahoui [brh]</td>
-<td>Pakistan, Afghanistan</td>
+<td>Biyabuneki [nyq]</td>
+<td>Iran</td>
 <td>Arabe</td>
-<td>2 864 400</td></tr>
-<tr>
-<td>Malais du Brunei [kxd]</td>
-<td>Brunei, Malaisie</td>
-<td>Arabe, latin</td>
-<td>321 000</td></tr>
+<td>7 030</td></tr>
 <tr>
 <td>Bourouchaski [bsk]</td>
 <td>Pakistan, Inde</td>
 <td>Arabe</td>
 <td>126 300</td></tr>
 <tr>
-<td>Tamazight du Maroc central [tzm]</td>
-<td>Maroc</td>
-<td>Arabe, tifinagh</td>
-<td>4 740 000</td></tr>
-<tr>
-<td>Kanouri central [knc]</td>
-<td>Nigéria</td>
-<td>Latin, arabe</td>
-<td>8 825 500</td></tr>
-<tr>
-<td>Sorani [ckb]</td>
-<td>Irak</td>
-<td>Arabe</td>
-<td>5 266 050</td></tr>
-<tr>
-<td>Pachto central [pst]</td>
-<td>Pakistan</td>
-<td>Arabe</td>
-<td>8 490 000</td></tr>
-<tr>
-<td>Arabe tchadien [shu]</td>
-<td>Tchad</td>
+<td>Bozo-jenaama [bze]</td>
+<td>Mali</td>
 <td>Arabe, latin</td>
-<td>2 061 220 </td></tr>
+<td>197 000</td></tr>
+<tr>
+<td>Bozo-tiéyaxo [boz]</td>
+<td>Mali</td>
+<td>Latin, arabe</td>
+<td>118 000</td></tr>
+<tr>
+<td>Brahoui [brh]</td>
+<td>Pakistan, Afghanistan</td>
+<td>Arabe</td>
+<td>2 864 400</td></tr>
+<tr>
+<td>Cachemiri ou kashmiri [kas]</td>
+<td>Inde</td>
+<td>Arabe, (devanagari)</td>
+<td>7 132 780</td></tr>
+<tr>
+<td>Cham occidental [cja]</td>
+<td>Cambodge</td>
+<td>Cham, arabe, latin</td>
+<td>312 500</td></tr>
+<tr>
+<td>Cham oriental [cjm]</td>
+<td>Viêt Nam</td>
+<td>Cham, (arabe)</td>
+<td>132 000</td></tr>
+<tr>
+<td>Chaoui [shy]</td>
+<td>Algérie</td>
+<td>Arabe, tifinagh</td>
+<td>2 300 000</td></tr>
 <tr>
 <td>Chittagonien [ctg]</td>
 <td>Bangladesh</td>
 <td>Bengali, arabe</td>
 <td>13 000 000</td></tr>
 <tr>
+<td>Chleuh [shi]</td>
+<td>Maroc</td>
+<td>Tifinagh, arabe</td>
+<td>5 118 000</td></tr>
+<tr>
+<td>Comorien anjouanais [wni]</td>
+<td>Comores</td>
+<td>Arabe, latin</td>
+<td>361 000</td></tr>
+<tr>
 <td>Copte [cop]</td>
 <td>Égypte</td>
 <td>Copte, arabe</td>
 <td>0 (liturgique)</td></tr>
-<tr>
-<td>Arabe chypriote maronite [acy]</td>
-<td>Chypre</td>
-<td>Latin, (arabe)</td>
-<td>9 760</td></tr>
 <tr>
 <td>Dameli [dml]</td>
 <td>Pakistan</td>
@@ -307,6 +455,26 @@ f.additionalLinks = ''
 <td>Arabe</td>
 <td>206 400</td></tr>
 <tr>
+<td>Diakhanké [jad]</td>
+<td>Guinée</td>
+<td>Arabe</td>
+<td>137 500</td></tr>
+<tr>
+<td>Dialectes du sud-ouest du Fars [fay]</td>
+<td>Iran</td>
+<td>Arabe</td>
+<td>110 000</td></tr>
+<tr>
+<td>Diola-fogny [dyo]</td>
+<td>Sénégal</td>
+<td>Arabe, latin</td>
+<td>457 000</td></tr>
+<tr>
+<td>Dioula [dyu]</td>
+<td>Côte d’Ivoire</td>
+<td>Arabe, latin, n’ko</td>
+<td>12 504 000</td></tr>
+<tr>
 <td>Dogri [dgo]</td>
 <td>Inde</td>
 <td>Devanagari, (arabe)</td>
@@ -317,65 +485,35 @@ f.additionalLinks = ''
 <td>Arabe</td>
 <td>200 000</td></tr>
 <tr>
-<td>Dioula [dyu]</td>
-<td>Côte d’Ivoire</td>
-<td>Arabe, latin, n’ko</td>
-<td>12 504 000</td></tr>
-<tr>
-<td>Baloutchi oriental [bgp]</td>
-<td>Inde, Pakistan</td>
-<td>Arabe</td>
-<td>2 930 800</td></tr>
-<tr>
-<td>Cham oriental [cjm]</td>
-<td>Viêt Nam</td>
-<td>Cham, (arabe)</td>
-<td>132 000</td></tr>
-<tr>
-<td>Arabe bedawi [avl]</td>
-<td>Égypte, Libye</td>
-<td>Arabe</td>
-<td>2 430 300</td></tr>
-<tr>
-<td>Malinké de l’Est [emk]</td>
-<td>Guinée</td>
-<td>Arabe, latin, n’ko</td>
-<td>3 722 300</td></tr>
-<tr>
-<td>Arabe égyptien [arz]</td>
-<td>Égypte, (nombreux médias)</td>
-<td>Arabe</td>
-<td>74 826 320</td></tr>
-<tr>
 <td>Gazi [gzi]</td>
 <td>Iran</td>
 <td>Arabe</td>
 <td>7 030</td></tr>
-<tr>
-<td>Guilaki [glk]</td>
-<td>Iran</td>
-<td>Arabe</td>
-<td>2 490 000</td></tr>
 <tr>
 <td>Goaria [gig]</td>
 <td>Pakistan</td>
 <td>Arabe</td>
 <td>25 400</td></tr>
 <tr>
-<td>Gowro [gwf]</td>
-<td>Pakistan</td>
-<td>Arabe</td>
-<td>1 000</td></tr>
-<tr>
 <td>Goujari [gju]</td>
 <td>Inde</td>
 <td>Arabe, (devanagari)</td>
 <td>1 696 000</td></tr>
 <tr>
-<td>Arabe du Golfe [afb]</td>
-<td>Koweït et pays environnants</td>
+<td>Gowro [gwf]</td>
+<td>Pakistan</td>
 <td>Arabe</td>
-<td>10 656 700</td></tr>
+<td>1 000</td></tr>
+<tr>
+<td>Grand-comorien [zdj]</td>
+<td>Comores</td>
+<td>Arabe, latin</td>
+<td>412 000</td></tr>
+<tr>
+<td>Guilaki [glk]</td>
+<td>Iran</td>
+<td>Arabe</td>
+<td>2 490 000</td></tr>
 <tr>
 <td>Gurani [hac]</td>
 <td>Iran</td>
@@ -387,6 +525,11 @@ f.additionalLinks = ''
 <td>Arabe</td>
 <td>35 300</td></tr>
 <tr>
+<td>Haoussa [hau]</td>
+<td>Nigéria et Sahel</td>
+<td>Latin, arabe</td>
+<td>77 063 700</td></tr>
+<tr>
 <td>Harzani [hrz]</td>
 <td>Iran</td>
 <td>Arabe</td>
@@ -397,20 +540,20 @@ f.additionalLinks = ''
 <td>Arabe</td>
 <td>4 883 500</td></tr>
 <tr>
-<td>Haoussa [hau]</td>
-<td>Nigéria et Sahel</td>
-<td>Latin, arabe</td>
-<td>77 063 700</td></tr>
-<tr>
 <td>Hazara [haz]</td>
 <td>Afghanistan, Pakistan</td>
 <td>Arabe</td>
 <td>3 628 900</td></tr>
 <tr>
-<td>Arabe hijazi [acw]</td>
-<td>Arabie saoudite</td>
+<td>Hindko du Nord [hno]</td>
+<td>Pakistan</td>
 <td>Arabe</td>
-<td>10 792 400</td></tr>
+<td>3 570 000</td></tr>
+<tr>
+<td>Hindko du Sud [hnd]</td>
+<td>Pakistan</td>
+<td>Arabe</td>
+<td>1 170 000</td></tr>
 <tr>
 <td>Ida’an [dbj]</td>
 <td>Malaisie</td>
@@ -422,60 +565,45 @@ f.additionalLinks = ''
 <td>Latin, (arabe)</td>
 <td>198 000 000</td></tr>
 <tr>
-<td>Kohistani de l’Indus [mvy]</td>
-<td>Pakistan</td>
-<td>Arabe</td>
-<td>200 000</td></tr>
-<tr>
 <td>Ingouche [inh]</td>
 <td>Russie</td>
 <td>Cyrillique, (arabe)</td>
 <td>306 000</td></tr>
-<tr>
-<td>Persan iranien [pes]</td>
-<td>Iran</td>
-<td>Arabe</td>
-<td>77 377 510</td></tr>
 <tr>
 <td>Jadgali [jdg]</td>
 <td>Pakistan</td>
 <td>Arabe</td>
 <td>25 600</td></tr>
 <tr>
-<td>Diakhanké [jad]</td>
+<td>Jalonké [yal]</td>
 <td>Guinée</td>
-<td>Arabe</td>
-<td>137 500</td></tr>
-<tr>
-<td>Bozo-jenaama [bze]</td>
-<td>Mali</td>
-<td>Arabe, latin</td>
-<td>197 000</td></tr>
-<tr>
-<td>Diola-fogny [dyo]</td>
-<td>Sénégal</td>
-<td>Arabe, latin</td>
-<td>457 000</td></tr>
+<td>Latin, arabe</td>
+<td>180 700</td></tr>
 <tr>
 <td>Kachi koli [gjk]</td>
 <td>Pakistan, Inde</td>
 <td>Arabe, (gujarati)</td>
 <td>530 000</td></tr>
 <tr>
-<td>Kohistani de Kalam [gwc]</td>
-<td>Pakistan</td>
+<td>Kachkaï [qxq]</td>
+<td>Iran</td>
 <td>Arabe</td>
-<td>96 400</td></tr>
+<td>995 000</td></tr>
 <tr>
 <td>Kalasha [kls]</td>
 <td>Pakistan</td>
 <td>Arabe</td>
 <td>5 000</td></tr>
 <tr>
-<td>Cachemiri ou kashmiri [kas]</td>
-<td>Inde</td>
-<td>Arabe, (devanagari)</td>
-<td>7 132 780</td></tr>
+<td>Kanouri central [knc]</td>
+<td>Nigéria</td>
+<td>Latin, arabe</td>
+<td>8 825 500</td></tr>
+<tr>
+<td>Kanouri manga [kby]</td>
+<td>Niger, Nigéria</td>
+<td>Latin, arabe</td>
+<td>480 000</td></tr>
 <tr>
 <td>Kati [bsh]</td>
 <td>Afghanistan</td>
@@ -487,16 +615,6 @@ f.additionalLinks = ''
 <td>Cyrillique, arabe</td>
 <td>12 695 140</td></tr>
 <tr>
-<td>Mattokki [xnz]</td>
-<td>Égypte, Libye</td>
-<td>Arabe, copte, latin</td>
-<td>50 000</td></tr>
-<tr>
-<td>Turc du Khorassan [kmz]</td>
-<td>Iran</td>
-<td>Arabe</td>
-<td>936 000</td></tr>
-<tr>
 <td>Khowar [khw]</td>
 <td>Pakistan</td>
 <td>Arabe</td>
@@ -507,10 +625,20 @@ f.additionalLinks = ''
 <td>Arabe</td>
 <td>26 400</td></tr>
 <tr>
-<td>Shina Kohistani [plk]</td>
+<td>Kirghize ou kirghiz [kir]</td>
+<td>Kirghizistan et pays environnants</td>
+<td>Cyrillique, latin, arabe</td>
+<td>5 132 100</td></tr>
+<tr>
+<td>Kohistani de Kalam [gwc]</td>
 <td>Pakistan</td>
 <td>Arabe</td>
-<td>458 000</td></tr>
+<td>96 400</td></tr>
+<tr>
+<td>Kohistani de l’Indus [mvy]</td>
+<td>Pakistan</td>
+<td>Arabe</td>
+<td>200 000</td></tr>
 <tr>
 <td>Koti [eko]</td>
 <td>Mozambique</td>
@@ -522,90 +650,110 @@ f.additionalLinks = ''
 <td>Cyrillique, latin, (arabe)</td>
 <td>427 600</td></tr>
 <tr>
-<td>Kirghize ou kirghiz [kir]</td>
-<td>Kirghizistan et pays environnants</td>
-<td>Cyrillique, latin, arabe</td>
-<td>5 132 100</td></tr>
+<td>Kurde du Sud [sdh]</td>
+<td>Iran</td>
+<td>Arabe</td>
+<td>3 730 000</td></tr>
+<tr>
+<td>Kurmandji [kmr]</td>
+<td>Turquie et plusieurs pays d’Asie de l’Ouest</td>
+<td>Arabe, latin, (arménien, cyrillique)</td>
+<td>15 703 920</td></tr>
 <tr>
 <td>Laki [lki]</td>
 <td>Iran</td>
 <td>Arabe</td>
 <td>1 240 000</td></tr>
 <tr>
-<td>Lari [lrl]</td>
-<td>Iran</td>
-<td>Arabe</td>
-<td>118 000</td></tr>
-<tr>
 <td>Lasgerdi [lsa]</td>
 <td>Iran</td>
 <td>Arabe</td>
 <td>1 000</td></tr>
 <tr>
-<td>Arabe libyen [ayl]</td>
-<td>Libye, Égypte, Niger</td>
+<td>Lari [lrl]</td>
+<td>Iran</td>
 <td>Arabe</td>
-<td>5 343 050</td></tr>
+<td>118 000</td></tr>
 <tr>
-<td>Peul du Macina [ffm]</td>
-<td>Mali et pays adjacents</td>
-<td>Latin, arabe</td>
-<td>1 523 240</td></tr>
+<td>Lori du Nord [lrc]</td>
+<td>Iran</td>
+<td>Arabe</td>
+<td>1 820 000</td></tr>
+<tr>
+<td>Lori du Sud [luz]</td>
+<td>Iran</td>
+<td>Arabe</td>
+<td>1 140 000</td></tr>
 <tr>
 <td>Maba (Tchad) [mde]</td>
 <td>Tchad</td>
 <td>Latin, arabe</td>
 <td>567 000</td></tr>
 <tr>
+<td>Mahorais [swb]</td>
+<td>Mayotte</td>
+<td>Latin, arabe</td>
+<td>185 500</td></tr>
+<tr>
 <td>Malais (langue individuelle) [zlm]</td>
 <td>Malaisie, Indonésie</td>
 <td>Latin, arabe</td>
 <td>19 185 470</td></tr>
+<tr>
+<td>Malais du Brunei [kxd]</td>
+<td>Brunei, Malaisie</td>
+<td>Arabe, latin</td>
+<td>321 000</td></tr>
+<tr>
+<td>Malaisien [zsm]</td>
+<td>Malaisie</td>
+<td>Latin, arabe</td>
+<td>(liturgique)</td></tr>
 <tr>
 <td>Malayalam [mal]</td>
 <td>Inde</td>
 <td>Malayalam, (arabe)</td>
 <td>37 212 270</td></tr>
 <tr>
+<td>Malinké de l’Est [emk]</td>
+<td>Guinée</td>
+<td>Arabe, latin, n’ko</td>
+<td>3 722 300</td></tr>
+<tr>
+<td>Malinké de l’Ouest [mlq]</td>
+<td>Sénégal, Mali</td>
+<td>Latin, arabe</td>
+<td>2 067 260</td></tr>
+<tr>
 <td>Mandinka [mnk]</td>
 <td>Sénégal, Guinée, Gambie</td>
 <td>Latin, arabe</td>
 <td>1 949 000</td></tr>
-<tr>
-<td>Kanouri manga [kby]</td>
-<td>Niger, Nigéria</td>
-<td>Latin, arabe</td>
-<td>480 000</td></tr>
-<tr>
-<td>Mahorais [swb]</td>
-<td>Mayotte</td>
-<td>Latin, arabe</td>
-<td>185 500</td></tr>
 <tr>
 <td>Marwari pakistanais [mve]</td>
 <td>Pakistan</td>
 <td>Arabe</td>
 <td>164 000</td></tr>
 <tr>
+<td>Mattokki [xnz]</td>
+<td>Égypte, Libye</td>
+<td>Arabe, copte, latin</td>
+<td>50 000</td></tr>
+<tr>
 <td>Mazandarani [mzn]</td>
 <td>Iran</td>
 <td>Arabe</td>
 <td>2 320 000</td></tr>
-<tr>
-<td>Arabe mésopotamien [acm]</td>
-<td>Irak et pays voisins</td>
-<td>Arabe</td>
-<td>19 063 530</td></tr>
 <tr>
 <td>Mogofin [mfg]</td>
 <td>Guinée</td>
 <td>Latin, (arabe)</td>
 <td>24 800</td></tr>
 <tr>
-<td>Arabe marocain [ary]</td>
-<td>Maroc, Tunisie, Algérie, Sahara occidental</td>
-<td>Arabe</td>
-<td>33 358 230</td></tr>
+<td>Mozabite [mzb]</td>
+<td>Algérie</td>
+<td>Latin, arabe, tifinagh</td>
+<td>150 000</td></tr>
 <tr>
 <td>Munji [mnj]</td>
 <td>Afghanistan</td>
@@ -622,110 +770,65 @@ f.additionalLinks = ''
 <td>Arabe</td>
 <td>297 000</td></tr>
 <tr>
-<td>Arabe najdi [ars]</td>
-<td>Arabie saoudite et pays voisins</td>
-<td>Arabe</td>
-<td>18 153 010</td></tr>
-<tr>
 <td>Natanzi [ntz]</td>
 <td>Iran</td>
 <td>Arabe</td>
 <td>7 030</td></tr>
-<tr>
-<td>Biyabuneki [nyq]</td>
-<td>Iran</td>
-<td>Arabe</td>
-<td>7 030</td></tr>
-<tr>
-<td>Comorien anjouanais [wni]</td>
-<td>Comores</td>
-<td>Arabe, latin</td>
-<td>361 000</td></tr>
-<tr>
-<td>Grand-comorien [zdj]</td>
-<td>Comores</td>
-<td>Arabe, latin</td>
-<td>412 000</td></tr>
-<tr>
-<td>Peul du Nigéria [fuv]</td>
-<td>Nigéria, Cameroun</td>
-<td>Arabe, latin</td>
-<td>16 585 000</td></tr>
 <tr>
 <td>Nobiin [fia]</td>
 <td>Soudan, Égypte</td>
 <td>Arabe, latin, copte</td>
 <td>546 000</td></tr>
 <tr>
-<td>Azéri du Nord [azj]</td>
-<td>Azerbaïdjan, Géorgie</td>
-<td>Latin, (cyrillique, arabe)</td>
-<td>9 220 620</td></tr>
-<tr>
-<td>Arabe levantin septentrional [apc]</td>
-<td>Syrie</td>
-<td>Arabe</td>
-<td>31 437 480</td></tr>
-<tr>
-<td>Arabe mésopotamien septentrional [ayp]</td>
-<td>Irak</td>
-<td>Arabe</td>
-<td>10 252 460</td></tr>
-<tr>
-<td>Hindko du Nord [hno]</td>
-<td>Pakistan</td>
-<td>Arabe</td>
-<td>3 570 000</td></tr>
-<tr>
-<td>Kurmandji [kmr]</td>
-<td>Turquie et plusieurs pays d’Asie de l’Ouest</td>
-<td>Arabe, latin, (arménien, cyrillique)</td>
-<td>15 703 920</td></tr>
-<tr>
-<td>Lori du Nord [lrc]</td>
-<td>Iran</td>
-<td>Arabe</td>
-<td>1 820 000</td></tr>
-<tr>
-<td>Pachto du Nord [pbu]</td>
-<td>Pakistan</td>
-<td>Arabe</td>
-<td>30 172 800</td></tr>
-<tr>
-<td>Ouzbek du Nord [uzn]</td>
-<td>Ouzbékistan et pays voisins, Chine</td>
-<td>Latin, arabe, (cyrillique)</td>
-<td>27 745 270</td></tr>
-<tr>
 <td>Od [odk]</td>
 <td>Inde</td>
 <td>Arabe</td>
 <td>2 076 100</td></tr>
-<tr>
-<td>Arabe omanais [acx]</td>
-<td>Oman</td>
-<td>Arabe</td>
-<td>2 877 200</td></tr>
 <tr>
 <td>Ormuri [oru]</td>
 <td>Pakistan</td>
 <td>Arabe</td>
 <td>5 050</td></tr>
 <tr>
+<td>Ouïghour [uig]</td>
+<td>Chine, Afghanistan</td>
+<td>Arabe</td>
+<td>10 411 822</td></tr>
+<tr>
+<td>Ourdou [urd]</td>
+<td>Pakistan</td>
+<td>Arabe</td>
+<td>231 295 440</td></tr>
+<tr>
+<td>Ouzbek du Nord [uzn]</td>
+<td>Ouzbékistan et pays voisins, Chine</td>
+<td>Latin, arabe, (cyrillique)</td>
+<td>27 745 270</td></tr>
+<tr>
+<td>Ouzbek du Sud [uzs]</td>
+<td>Afghanistan</td>
+<td>Arabe</td>
+<td>5 296 100</td></tr>
+<tr>
+<td>Pachto central [pst]</td>
+<td>Pakistan</td>
+<td>Arabe</td>
+<td>8 490 000</td></tr>
+<tr>
+<td>Pachto du Nord [pbu]</td>
+<td>Pakistan</td>
+<td>Arabe</td>
+<td>30 172 800</td></tr>
+<tr>
+<td>Pachto du Sud [pbt]</td>
+<td>Afghanistan</td>
+<td>Arabe</td>
+<td>19 732 400</td></tr>
+<tr>
 <td>Pahari potwari [phr]</td>
 <td>Pakistan, Inde</td>
 <td>Arabe</td>
 <td>3 541 900</td></tr>
-<tr>
-<td>Phalura [phl]</td>
-<td>Pakistan</td>
-<td>Arabe</td>
-<td>14 400</td></tr>
-<tr>
-<td>Pendjabi [pan]</td>
-<td>Inde</td>
-<td>Gourmoukhî, arabe, (khojki)</td>
-<td>51 724 270</td></tr>
 <tr>
 <td>Parkari koli [kvx]</td>
 <td>Pakistan</td>
@@ -737,10 +840,50 @@ f.additionalLinks = ''
 <td>Arabe</td>
 <td>27 500</td></tr>
 <tr>
-<td>Yawi [mfa]</td>
-<td>Thaïlande</td>
-<td>Arabe, thaï</td>
-<td>1 470 000</td></tr>
+<td>Pashai du Sud-Est [psi]</td>
+<td>Afghanistan</td>
+<td>Arabe</td>
+<td>366 000</td></tr>
+<tr>
+<td>Pendjabi [pan]</td>
+<td>Inde</td>
+<td>Gourmoukhî, arabe, (khojki)</td>
+<td>51 724 270</td></tr>
+<tr>
+<td>Pendjabi de l’Ouest [pnb]</td>
+<td>Pakistan</td>
+<td>Arabe, (khojki)</td>
+<td>66 441 240</td></tr>
+<tr>
+<td>Persan iranien [pes]</td>
+<td>Iran</td>
+<td>Arabe</td>
+<td>77 377 510</td></tr>
+<tr>
+<td>Peul de l’Adamaoua [fub]</td>
+<td>Cameroun</td>
+<td>Arabe</td>
+<td>5 685 500</td></tr>
+<tr>
+<td>Peul du Macina [ffm]</td>
+<td>Mali et pays adjacents</td>
+<td>Latin, arabe</td>
+<td>1 523 240</td></tr>
+<tr>
+<td>Peul du Niger occidental [fuh]</td>
+<td>Niger et pays voisins</td>
+<td>Latin, arabe</td>
+<td>2 320 000</td></tr>
+<tr>
+<td>Peul du Nigéria [fuv]</td>
+<td>Nigéria, Cameroun</td>
+<td>Arabe, latin</td>
+<td>16 585 000</td></tr>
+<tr>
+<td>Phalura [phl]</td>
+<td>Pakistan</td>
+<td>Arabe</td>
+<td>14 400</td></tr>
 <tr>
 <td>Pulaar [fuc]</td>
 <td>Sénégal</td>
@@ -757,10 +900,10 @@ f.additionalLinks = ''
 <td>Arabe, (tibétain)</td>
 <td>93 500</td></tr>
 <tr>
-<td>Kachkaï [qxq]</td>
-<td>Iran</td>
-<td>Arabe</td>
-<td>995 000</td></tr>
+<td>Rifain [rif]</td>
+<td>Maroc</td>
+<td>Latin, arabe, tifinagh</td>
+<td>4 399 000</td></tr>
 <tr>
 <td>Rohingya [rhg]</td>
 <td>Birmanie, Bangladesh</td>
@@ -771,16 +914,6 @@ f.additionalLinks = ''
 <td>Sénégal</td>
 <td>Arabe, latin</td>
 <td>200 000</td></tr>
-<tr>
-<td>Arabe saïdi [aec]</td>
-<td>Égypte, Libye</td>
-<td>Arabe</td>
-<td>24 100 000</td></tr>
-<tr>
-<td>Arabe sanaani [ayn]</td>
-<td>Yémen</td>
-<td>Arabe</td>
-<td>12 567 960</td></tr>
 <tr>
 <td>Sangsari [sgr]</td>
 <td>Iran</td>
@@ -807,6 +940,11 @@ f.additionalLinks = ''
 <td>Arabe</td>
 <td>720 200</td></tr>
 <tr>
+<td>Shina Kohistani [plk]</td>
+<td>Pakistan</td>
+<td>Arabe</td>
+<td>458 000</td></tr>
+<tr>
 <td>Shughni [sgh]</td>
 <td>Tadjikistan, Afghanistan</td>
 <td>Latin, cyrillique, arabe</td>
@@ -832,125 +970,40 @@ f.additionalLinks = ''
 <td>Latin, arabe</td>
 <td>111 000</td></tr>
 <tr>
-<td>Azéri du sud [azb]</td>
-<td>Iran et pays voisins</td>
+<td>Sorani [ckb]</td>
+<td>Irak</td>
 <td>Arabe</td>
-<td>14 629 370</td></tr>
-<tr>
-<td>Arabe levantin méridional [ajp]</td>
-<td>Jordanie, Syrie</td>
-<td>Arabe</td>
-<td>12 711 300</td></tr>
-<tr>
-<td>Pashai du Sud-Est [psi]</td>
-<td>Afghanistan</td>
-<td>Arabe</td>
-<td>366 000</td></tr>
-<tr>
-<td>Baloutchi du Sud [bcc]</td>
-<td>Pakistan</td>
-<td>Arabe</td>
-<td>3 555 700</td></tr>
-<tr>
-<td>Hindko du Sud [hnd]</td>
-<td>Pakistan</td>
-<td>Arabe</td>
-<td>1 170 000</td></tr>
-<tr>
-<td>Kurde du Sud [sdh]</td>
-<td>Iran</td>
-<td>Arabe</td>
-<td>3 730 000</td></tr>
-<tr>
-<td>Lori du Sud [luz]</td>
-<td>Iran</td>
-<td>Arabe</td>
-<td>1 140 000</td></tr>
-<tr>
-<td>Pachto du Sud [pbt]</td>
-<td>Afghanistan</td>
-<td>Arabe</td>
-<td>19 732 400</td></tr>
-<tr>
-<td>Ouzbek du Sud [uzs]</td>
-<td>Afghanistan</td>
-<td>Arabe</td>
-<td>5 296 100</td></tr>
-<tr>
-<td>Dialectes du sud-ouest du Fars [fay]</td>
-<td>Iran</td>
-<td>Arabe</td>
-<td>110 000</td></tr>
-<tr>
-<td>Arabe standard moderne [arb]</td>
-<td>Très répandu</td>
-<td>Arabe</td>
-<td>273 989 700</td></tr>
-<tr>
-<td>Malaisien [zsm]</td>
-<td>Malaisie</td>
-<td>Latin, arabe</td>
-<td>(liturgique)</td></tr>
-<tr>
-<td>Arabe soudanais [apd]</td>
-<td>Soudan</td>
-<td>Arabe, latin</td>
-<td>42 332 360</td></tr>
-<tr>
-<td>Soundanais [sun]</td>
-<td>Indonésie</td>
-<td>Latin, (arabe, javanais)</td>
-<td>36 700 000</td></tr>
+<td>5 266 050</td></tr>
 <tr>
 <td>Soso, soussou ou susu [sus]</td>
 <td>Guinée</td>
 <td>Latin, arabe</td>
 <td>2 434 140</td></tr>
 <tr>
+<td>Soundanais [sun]</td>
+<td>Indonésie</td>
+<td>Latin, (arabe, javanais)</td>
+<td>36 700 000</td></tr>
+<tr>
 <td>Swahili [swh]</td>
 <td>Tanzanie et pays voisins</td>
 <td>Latin, (arabe)</td>
 <td>71 416 500</td></tr>
-<tr>
-<td>Arabe ta’izzi-adeni [acq]</td>
-<td>Yémen</td>
-<td>Arabe</td>
-<td>11 821 100</td></tr>
-<tr>
-<td>Chaoui [shy]</td>
-<td>Algérie</td>
-<td>Arabe, tifinagh</td>
-<td>2 300 000</td></tr>
-<tr>
-<td>Chleuh [shi]</td>
-<td>Maroc</td>
-<td>Tifinagh, arabe</td>
-<td> 5 118 000</td></tr>
 <tr>
 <td>Tadaksahak [dsq]</td>
 <td>Mali</td>
 <td>Arabe, latin</td>
 <td>159 800</td></tr>
 <tr>
-<td>Tagdal [tda]</td>
-<td>Niger</td>
-<td>Latin, arabe, tifinagh</td>
-<td>60 600</td></tr>
-<tr>
-<td>Tamahaq tahaggart [thv]</td>
-<td>Algérie</td>
-<td>Latin, arabe, tifinagh</td>
-<td>114 200</td></tr>
-<tr>
 <td>Tadjik [tgk]</td>
 <td>Tadjikistan</td>
 <td>Latin, (cyrillique, arabe)</td>
 <td>8 195 120</td></tr>
 <tr>
-<td>Arabe tadjik [abh]</td>
-<td>Tadjikistan</td>
-<td>Arabe</td>
-<td>17 300</td></tr>
+<td>Tagdal [tda]</td>
+<td>Niger</td>
+<td>Latin, arabe, tifinagh</td>
+<td>60 600</td></tr>
 <tr>
 <td>Takestani [tks]</td>
 <td>Iran</td>
@@ -962,10 +1015,15 @@ f.additionalLinks = ''
 <td>Latin, arabe, cyrillique</td>
 <td>226 100</td></tr>
 <tr>
-<td>Rifain [rif]</td>
-<td>Maroc</td>
+<td>Tamahaq tahaggart [thv]</td>
+<td>Algérie</td>
 <td>Latin, arabe, tifinagh</td>
-<td>4 399 000</td></tr>
+<td>114 200</td></tr>
+<tr>
+<td>Tamazight du Maroc central [tzm]</td>
+<td>Maroc</td>
+<td>Arabe, tifinagh</td>
+<td>4 740 000</td></tr>
 <tr>
 <td>Tausug [tsg]</td>
 <td>Philippines</td>
@@ -982,45 +1040,25 @@ f.additionalLinks = ''
 <td>Latin, arabe</td>
 <td>390 200</td></tr>
 <tr>
-<td>Bozo-tiéyaxo [boz]</td>
-<td>Mali</td>
-<td>Latin, arabe</td>
-<td>118 000</td></tr>
-<tr>
 <td>Torwali [trw]</td>
 <td>Pakistan</td>
 <td>Arabe</td>
 <td>114 000</td></tr>
-<tr>
-<td>Mozabite [mzb]</td>
-<td>Algérie</td>
-<td>Latin, arabe, tifinagh</td>
-<td>150 000</td></tr>
-<tr>
-<td>Arabe tunisien [aeb]</td>
-<td>Tunisie</td>
-<td>Arabe</td>
-<td>11 709 020</td></tr>
 <tr>
 <td>Turc [tur]</td>
 <td>Turquie</td>
 <td>Latin, (arabe)</td>
 <td>88 098 480</td></tr>
 <tr>
+<td>Turc du Khorassan [kmz]</td>
+<td>Iran</td>
+<td>Arabe</td>
+<td>936 000</td></tr>
+<tr>
 <td>Turkmène [tuk]</td>
 <td>Turkménistan, Afghanistan</td>
 <td>Latin, arabe, cyrillique</td>
 <td>6 656 060</td></tr>
-<tr>
-<td>Ourdou [urd]</td>
-<td>Pakistan</td>
-<td>Arabe</td>
-<td>231 295 440</td></tr>
-<tr>
-<td>Ouïghour [uig]</td>
-<td>Chine, Afghanistan</td>
-<td>Arabe</td>
-<td>10 411 822</td></tr>
 <tr>
 <td>Vafsi [vaf]</td>
 <td>Iran</td>
@@ -1037,31 +1075,6 @@ f.additionalLinks = ''
 <td>Arabe, latin, cyrillique</td>
 <td>52 200</td></tr>
 <tr>
-<td>Baloutchi occidental [bgn]</td>
-<td>Pakistan, Turkménistan</td>
-<td>Arabe, cyrillique</td>
-<td>2 264 350</td></tr>
-<tr>
-<td>Cham occidental [cja]</td>
-<td>Cambodge</td>
-<td>Cham, arabe, latin</td>
-<td>312 500</td></tr>
-<tr>
-<td>Malinké de l’Ouest [mlq]</td>
-<td>Sénégal, Mali</td>
-<td>Latin, arabe</td>
-<td>2 067 260</td></tr>
-<tr>
-<td>Peul du Niger occidental [fuh]</td>
-<td>Niger et pays voisins</td>
-<td>Latin, arabe</td>
-<td>2 320 000</td></tr>
-<tr>
-<td>Pendjabi de l’Ouest [pnb]</td>
-<td>Pakistan</td>
-<td>Arabe, (khojki)</td>
-<td>66 441 240</td></tr>
-<tr>
 <td>Wolio [wlo]</td>
 <td>Indonésie</td>
 <td>Arabe</td>
@@ -1077,10 +1090,10 @@ f.additionalLinks = ''
 <td>Latin, arabe</td>
 <td>130 000</td></tr>
 <tr>
-<td>Jalonké [yal]</td>
-<td>Guinée</td>
-<td>Latin, arabe</td>
-<td>180 700</td></tr>
+<td>Yawi [mfa]</td>
+<td>Thaïlande</td>
+<td>Arabe, thaï</td>
+<td>1 470 000</td></tr>
 <tr>
 <td>Yidgha [ydg]</td>
 <td>Pakistan</td>
@@ -1115,16 +1128,22 @@ f.additionalLinks = ''
 
 <tr>
 <td rowspan="8">Hébreu</td>
+<td>Arabe judéo-irakien [yhd]</td>
+<td>Israël</td>
+<td>Hébreu</td>
+<td>97 200</td>
+</tr>
+<tr>
+<td>Arabe judéo-marocain [aju]</td>
+<td>Maroc</td>
+<td>Hébreu</td>
+<td>65 910</td>
+</tr>
+<tr>
 <td>Boukhori [bhh]</td>
 <td>Israël</td>
 <td>Cyrillique (hébreu)</td>
 <td>117 840</td>
-</tr>
-<tr>
-<td>Yiddish oriental [ydd]</td>
-<td>Israël</td>
-<td>Hébreu</td>
-<td>371 657</td>
 </tr>
 <tr>
 <td>Hébreu [heb]</td>
@@ -1139,18 +1158,6 @@ f.additionalLinks = ''
 <td>350</td>
 </tr>
 <tr>
-<td>Arabe judéo-irakien [yhd]</td>
-<td>Israël</td>
-<td>Hébreu</td>
-<td>97 200</td>
-</tr>
-<tr>
-<td>Arabe judéo-marocain [aju]</td>
-<td>Maroc</td>
-<td>Hébreu</td>
-<td>65 910</td>
-</tr>
-<tr>
 <td>Judéo-persan [jpr]</td>
 <td>Israël</td>
 <td>Hébreu</td>
@@ -1162,17 +1169,11 @@ f.additionalLinks = ''
 <td>Cyrillique (hébreu, latin)</td>
 <td>81 500</td>
 </tr>
-
-
-
-
-
 <tr>
-<td>Mandéen</td>
-<td>Néo-mandéen [mid]</td>
-<td>Iran</td>
-<td>Mandéen</td>
-<td>23 000</td>
+<td>Yiddish oriental [ydd]</td>
+<td>Israël</td>
+<td>Hébreu</td>
+<td>371 657</td>
 </tr>
 
 
@@ -1185,6 +1186,18 @@ f.additionalLinks = ''
 <td> Libéria, Sierra Leone</td>
 <td>Latin (kikakui)</td>
 <td>2 511 600</td>
+</tr>
+
+
+
+
+
+<tr>
+<td>Mandéen</td>
+<td>Néo-mandéen [mid]</td>
+<td>Iran</td>
+<td>Mandéen</td>
+<td>23 000</td>
 </tr>
 
 
@@ -1230,19 +1243,6 @@ f.additionalLinks = ''
 
 
 <tr>
-<td>Ancien hongrois</td>
-<td>Hongrois [hun]</td>
-<td>Hongrie</td>
-<td>Latin, (ancien hongrois)</td>
-<td>12 560 490</td>
-</tr>
-
-
-
-
-
-
-<tr>
 <td>Samaritain</td>
 <td>Araméen samaritain [sam]</td>
 <td>Israël, Palestine</td>
@@ -1258,16 +1258,16 @@ f.additionalLinks = ''
 
 <tr>
 <td rowspan="4">Syriaque</td>
-<td>Soureth [aii]</td>
-<td>Irak, Turquie, Syrie</td>
-<td>Cyrillique, syriaque</td>
-<td>594 050</td>
-</tr>
-<tr>
 <td>Néo-araméen chaldéen [cld]</td>
 <td>Irak</td>
 <td>Syriaque</td>
 <td>232 480</td>
+</tr>
+<tr>
+<td>Soureth [aii]</td>
+<td>Irak, Turquie, Syrie</td>
+<td>Cyrillique, syriaque</td>
+<td>594 050</td>
 </tr>
 <tr>
 <td>Syriaque classique [syr]</td>

--- a/questions/qa-scripts.fr.html
+++ b/questions/qa-scripts.fr.html
@@ -40,6 +40,8 @@ f.additionalLinks = ''
 <script src="../javascript/articletoc-2022.js"></script>
 <link rel="stylesheet" href="../style/article-2022.css">
 <link rel="copyright" href="#copyright">
+
+<style>tr td:last-child {text-align:right;}</style>
 </head>
 
 <body>
@@ -123,17 +125,33 @@ f.additionalLinks = ''
 <section id="directions">
 <h3>Quelles langues peuvent s’écrire à l’aide d’écritures de droite à gauche ?</h3>
 
-<p>Le tableau suivant donne un aperçu des langues parlées modernes qui peuvent s’écrire à l’aide d’écritures de droite à gauche. Il indique également dans quels pays on les parle. Certaines langues moins parlées ne sont pas mentionnées. Ces données sont issues de la base de données <a href="https://www.ethnologue.com">Ethnologue</a> de SIL International.</p>
+<p>Le tableau suivant donne un aperçu des langues parlées modernes qui peuvent s’écrire à l’aide d’écritures de droite à gauche. Il indique également dans quels pays on les parle. De plus :</p>
 
 <ul>
 <li>La colonne <samp>Écritures utilisées</samp> indique toutes les écritures qui peuvent servir à noter la langue concernée. L’ordre relatif donne une vague idée de la fréquence d’utilisation. Lorsqu’une écriture est peu utilisée, elle est indiquée entre parenthèses.</li>
 <li>La colonne <samp>Locuteurs potentiels</samp> indique le nombre de locuteurs et locutrices de la langue concernée (qu’il s’agisse de leur première ou de leur seconde langue). Ces chiffres ne tiennent pas compte des personnes qui n’utilisent ces langues que dans un cadre religieux.</li>
 </ul>
 
+<p>Ces données sont issues de la base de données <a href="https://www.ethnologue.com">Ethnologue</a> de SIL International.</p>
+
+<h4>Combien de langues s’écrivent de droite à gauche ?</h4>
+
+<p>Ce tableau liste 12 écritures et 215 langues. Certaines langues moins parlées ne sont pas mentionnées.</p>
+
+<div class="sidenoteGroup">
+    <p>Très largement utilisée, l’écriture arabe permet d’écrire 189 langues, qui comptent ensemble plus de deux milliards de locuteurs potentiels. Aucune distinction n’est faite entre les différents styles de l’écriture arabe, comme le nastaliq, le maghribi et le kano, ou entre les orthographes qui sont des <a class="termref" href="https://w3c.github.io/i18n-glossary/#dfn-abjad">abjads</a> (alphabets consonantiques) et celles qui sont des <a class="termref" href="https://w3c.github.io/i18n-glossary/#dfn-alphabet">alphabets</a>. Comme nous l’avons vu plus haut, le nombre de personnes qui utilisent l’arabe en raison de leur religion n’est pas non plus pris en compte.</p>
+
+    <aside class="sideinfonote">
+        <p class="info">Les voyelles brèves de l’écriture (ou orthographe) arabe sont représentées par des signes diacritiques.</p>
+        <p>Lorsqu’on utilise cette écriture pour représenter la langue arabe, on omet ces signes diacritiques, si bien que les voyelles brèves ne sont pas indiquées. Dans ce cas, on dit que l’écriture arabe est un « abjad », comme les écritures syriaque et ourdou.</p>
+        <p>En revanche, quand on l’utilise pour représenter certaines langues (comme la plupart des langues africaines, le cachemiri et l’ouïghour), on note toutes les voyelles, y compris les voyelles brèves. L’écriture arabe est alors un « alphabet ».</p>
+
+    </aside>
+</div>
+
+<h4>Combien de personnes utilisent des écritures de droite à gauche ?</h4>
+
 <p>Le nombre de locuteurs et locutrices est une surestimation, car il ne tient pas compte du degré d’alphabétisation, des écritures concurrentes ou des tendances d’utilisation. Néanmoins, si on additionne les chiffres du tableau, on arrive à un total de 2 305 048 719. Le nombre réel de locuteurs et locutrices dépasse donc probablement le milliard.</p>
-
-<p>Ce tableau liste 12 écritures et 215 langues. Très largement utilisée, l’écriture arabe permet d’écrire 189 langues, qui comptent ensemble plus de deux milliards de locuteurs potentiels. Aucune distinction n’est faite entre les différents styles de l’écriture arabe, comme le nastaliq, le maghribi et le kano, ou entre les orthographes qui sont des <a class="termref" href="https://w3c.github.io/i18n-glossary/#dfn-abjad">abjads</a> (alphabets consonantiques) et celles qui sont des <a class="termref" href="https://w3c.github.io/i18n-glossary/#dfn-alphabet">alphabets</a>. Comme nous l’avons vu plus haut, le nombre de personnes qui utilisent l’arabe en raison de leur religion n’est pas non plus pris en compte.</p>
-
 
 <table class="inband" id="table2">
 <tbody>


### PR DESCRIPTION
@r12a The following sequence of characters appears twice in the document: ï»¿
It represents the BOM signature in the Latin 1 encoding.
Should we wrap it in a tag?

Rendered: https://deploy-preview-477--i18n-drafts.netlify.app/questions/qa-byte-order-mark.fr.html