### PR TITLE
Update implnote on qa-html-dir: firefox implements dirname

### DIFF
--- a/questions/qa-html-dir.html
+++ b/questions/qa-html-dir.html
@@ -607,8 +607,7 @@ etc.</code>
 <div class="sidenoteGroup">
 <p>When you cause the browser to dynamically apply the correct direction to text in a form field, either by using <code>dir=&quot;auto&quot;</code>, by using JavaScript, or even by using <a href="#userexplicit">browser-specific keystrokes</a> or context menus,  the <code class="kw" translate="no">dirname</code> attribute  allows you to pass that information to the server, so that it can be re-used when the text is displayed in another context.</p>
 <aside class="implnote">
-<p class="impl"><img src="../icons/chrome_16x16.png" width="16" height="16" alt="Chrome" title="Chrome"> <img src="../icons/safari_16x16.png" width="16" height="16" alt="Safari" title="Safari">  <img src="../icons/edge_16x16.png" width="16" height="16" alt="Edge" title="Edge"><img src="../icons/ok.png" alt="OK" style="margin-left: 0.5em;"></p>
-<p><img src="../icons/firefox_16x16.png" width="16" height="16" alt="Firefox" title="Firefox"> <img src="../icons/fail.png" alt="fail" style="margin-left: 0.5em;"></p>
+<p class="impl"><img src="../icons/firefox_16x16.png" width="16" height="16" alt="Firefox" title="Firefox"> <img src="../icons/chrome_16x16.png" width="16" height="16" alt="Chrome" title="Chrome"> <img src="../icons/safari_16x16.png" width="16" height="16" alt="Safari" title="Safari">  <img src="../icons/edge_16x16.png" width="16" height="16" alt="Edge" title="Edge"><img src="../icons/ok.png" alt="OK" style="margin-left: 0.5em;"></p>
 </aside>
 </div>
 


### PR DESCRIPTION
As of [116.0a1](https://www.mozilla.org/en-US/firefox/116.0a1/releasenotes/), firefox supports the `dirname` attribute. This pull request updates the implnote on qa-html-dir.html.