### PR TITLE
Fix typo in CSS

### DIFF
--- a/articles/vertical-text/index.en.html
+++ b/articles/vertical-text/index.en.html
@@ -135,7 +135,7 @@ figure pre {
 <div class="sidenoteGroup">
 <figure id="fig_mongolian" class="example">
 <pre><code class="language-css">div.vertical-panel {
-    writing-mode: vertical-rl;
+    writing-mode: vertical-lr;
     }</code></pre>
 </figure>
 


### PR DESCRIPTION
Mongolian uses `vertical-lr`.