### PR TITLE
Make the contact sections consistent

### DIFF
--- a/nav/about.html
+++ b/nav/about.html
@@ -430,7 +430,6 @@ Group-only list: <a href="https://lists.w3.org/Archives/Public/public-tlreq-admi
 <li><a href="mailto:xfq@w3.org">Fuqiao Xue (xfq @ w3.org)</a>, Activity Lead, Staff Contact for Core Working Group</li>
 <li><a href="mailto:ishida@w3.org">Richard Ishida (ishida @ w3.org)</a>, Staff Contact for Core Working Group</li>
 <li><a href="mailto:duerst@it.aoyama.ac.jp">Martin Dürst (duerst @ it.aoyama.ac.jp)</a>, Interest Group Chair</li>
-<li><a href="http://www.w3.org/International/Group/#liaison">Liaisons</a> (member-only link)</li>
 </ul>
 </section>
 </section>

--- a/nav/about.zh-hans.html
+++ b/nav/about.zh-hans.html
@@ -417,7 +417,6 @@ GitHub: <a href="https://github.com/w3c/tlreq/">w3c/tlreq</a><br>
 <li><a href="mailto:xfq@w3.org">薛富侨 (xfq @ w3.org)</a>（国际化标准计划负责人，工作组联系人）</li>
 <li><a href="mailto:ishida@w3.org">Richard Ishida (ishida @ w3.org)</a>（国际化工作组联系人）</li>
 <li><a href="mailto:duerst@it.aoyama.ac.jp">Martin Dürst (duerst @ it.aoyama.ac.jp)</a>（国际化兴趣组主席）</li>
-<li><a href="http://www.w3.org/International/Group/#liaison">与其他组织的联络</a>（仅W3C会员可见）</li>
 </ul>
 </section>
 </section>

--- a/nav/ask.html
+++ b/nav/ask.html
@@ -20,7 +20,7 @@ f.status = 'notreviewed';  // should be one of draft, review, published, notrevi
 f.path = '' // what you need to prepend to a URL to get to the /International directory 
 
 // AUTHORS AND TRANSLATORS should fill in these assignments:
-f.thisVersion = { date:'2016-05-06', time:'12:05'} // date and time of latest edits to this document/translation
+f.thisVersion = { date:'2024-11-28', time:'12:05'} // date and time of latest edits to this document/translation
 f.contributors = ''; // people providing useful contributions or feedback during review or at other times
 // also make sure that the lang attribute on the html tag is correct!
 
@@ -87,10 +87,10 @@ strong { font-weight: 500; }
 <section id="contacts">
 <h2>Who can I contact?</h2>
 <ul>
-    <li><a href="mailto:addisoni18n@gmail.com">Addison Phillips (addisoni18n @ gmail.com)</a>, Internationalization Working Group Chair</li>
-    <li><a href="mailto:ishida@w3.org">Richard Ishida (ishida @ w3.org)</a>, Activity Lead, Staff Contact for Core Working Group</li>
-<li><a href="mailto:duerst@it.aoyama.ac.jp">Martin Dürst (duerst @ it.aoyama.ac.jp)</a>, Interest Group Chair</li>
-    <li><a href="http://www.w3.org/International/Group/#liaison">Liaisons</a> (member only)</li>
+  <li><a href="mailto:addisoni18n@gmail.com">Addison Phillips (addisoni18n @ gmail.com)</a>, Internationalization Working Group Chair</li>
+  <li><a href="mailto:xfq@w3.org">Fuqiao Xue (xfq @ w3.org)</a>, Activity Lead, Staff Contact for Core Working Group</li>
+  <li><a href="mailto:ishida@w3.org">Richard Ishida (ishida @ w3.org)</a>, Staff Contact for Core Working Group</li>
+  <li><a href="mailto:duerst@it.aoyama.ac.jp">Martin Dürst (duerst @ it.aoyama.ac.jp)</a>, Interest Group Chair</li>
 </ul>
 </section>
 


### PR DESCRIPTION
I also removed the link to the old Liaisons page. Now we can refer to this W3C-wide page: https://www.w3.org/liaisons/