### PR TITLE
Update links to Apache documentation

### DIFF
--- a/questions/qa-apache-lang-neg.de.html
+++ b/questions/qa-apache-lang-neg.de.html
@@ -20,7 +20,7 @@ f.status = 'published'  // should be one of draft, review, published, notreviewe
 f.path = '../' // what you need to prepend to a URL to get to the /International directory 
 
 // AUTHORS AND TRANSLATORS should fill in these assignments:
-f.thisVersion = { date:'2016-03-03', time:'13:08'} // date and time of latest edits to this document/translation
+f.thisVersion = { date:'2025-05-22', time:'13:08'} // date and time of latest edits to this document/translation
 f.contributors = '' // people providing useful contributions or feedback during review or at other times
 // also make sure that the lang attribute on the html tag is correct!
 f.sources = '' // describes sources of information
@@ -128,7 +128,7 @@ f.additionalLinks = ''
 
   <section id="directives">
 <h3>Server-Direktiven</h3>
-    <p>Normalerweise verwendet man die <span class="kw"><a class="print" href="http://httpd.apache.org/docs-2.0/mod/mod_mime.html#addlanguage">AddLanguage</a></span>-Direktive um
+    <p>Normalerweise verwendet man die <span class="kw"><a class="print" href="https://httpd.apache.org/docs/2.4/mod/mod_mime.html#addlanguage">AddLanguage</a></span>-Direktive um
       anzugeben, welche Dateiendung mit welcher per HTTP für den Inhalt angegebenen Sprache verknüpft ist.</p>
     <p>Die folgene Direktive verknüpft z.B. den HTTP-Request nach Inhalt auf Französisch mit der Dateiendung .fr: </p>
     <blockquote>
@@ -158,7 +158,7 @@ f.additionalLinks = ''
 
   <section id="specdef2">
 <h3>Default-Dateien in Apache ab 2.0.30 festlegen </h3>
-    <p>Ab Version 2.0.30 gibt es auf Apache-Servern eine saubere Lösung, um eine Default-Datei festzulegen: die Direktiven <span class="kw"><a class="print" href="http://httpd.apache.org/docs-2.0/mod/mod_negotiation.html#forcelanguagepriority">ForceLanguagePriority</a></span> und <span class="kw"><a class="print" href="http://httpd.apache.org/docs-2.0/mod/mod_negotiation.html#languagepriority">LanguagePriority</a></span>. (Folgen Sie den Links
+    <p>Ab Version 2.0.30 gibt es auf Apache-Servern eine saubere Lösung, um eine Default-Datei festzulegen: die Direktiven <span class="kw"><a class="print" href="https://httpd.apache.org/docs/2.4/mod/mod_negotiation.html#ForceLanguagePriority">ForceLanguagePriority</a></span> und <span class="kw"><a class="print" href="https://httpd.apache.org/docs/2.4/mod/mod_negotiation.html#languagepriority">LanguagePriority</a></span>. (Folgen Sie den Links
       zu ausführlichen Beschreibungen, wie diese Direktiven arbeiten).</p>
     <p>Für das obige Beispiel können wir durch folgende zwei Zeilen den Default auf Englisch setzen:</p>
     <blockquote>
@@ -214,7 +214,7 @@ f.additionalLinks = ''
       <p><a href="http://httpd.apache.org/docs/content-negotiation.html">Apache Version 1: Dokumentation zu Inhaltsvereinbarung (<span lang="en">content negotiation</span>)</a> </p>
     </li>
     <li>
-      <p><a href="http://httpd.apache.org/docs-2.0/content-negotiation.html">Apache Version 2: Dokumentation zu Inhaltsvereinbarung (<span lang="en">content negotiation</span>)</a> </p>
+      <p><a href="https://httpd.apache.org/docs/2.4/content-negotiation.html">Apache Version 2.4: Dokumentation zu Inhaltsvereinbarung (<span lang="en">content negotiation</span>)</a> </p>
     </li>
     <li>
       <p>Verwandte Links: <cite>Server-Konfiguration</cite></p>

--- a/questions/qa-apache-lang-neg.en.html
+++ b/questions/qa-apache-lang-neg.en.html
@@ -20,7 +20,7 @@ f.status = 'published'  // should be one of draft, review, published, notreviewe
 f.path = '../' // what you need to prepend to a URL to get to the /International directory 
 
 // AUTHORS AND TRANSLATORS should fill in these assignments:
-f.thisVersion = { date:'2016-03-03', time:'13:08'} // date and time of latest edits to this document/translation
+f.thisVersion = { date:'2025-05-22', time:'13:08'} // date and time of latest edits to this document/translation
 f.contributors = '' // people providing useful contributions or feedback during review or at other times
 // also make sure that the lang attribute on the html tag is correct!
 f.sources = '' // describes sources of information
@@ -134,7 +134,7 @@ f.additionalLinks = ''
 
   <section id="directives">
 <h3>Server directives</h3>
-    <p>You would normally use the <span class="kw"><a class="print" href="http://httpd.apache.org/docs-2.0/mod/mod_mime.html#addlanguage">AddLanguage</a></span> directive to
+    <p>You would normally use the <span class="kw"><a class="print" href="https://httpd.apache.org/docs/2.4/mod/mod_mime.html#addlanguage">AddLanguage</a></span> directive to
       specify which extension maps to which content language specified in the incoming HTTP.</p>
     <p>For example, the following directive maps the HTTP content language request for French to the extension .fr: </p>
     <blockquote>
@@ -161,7 +161,7 @@ f.additionalLinks = ''
 
   <section id="specdef2">
 <h3>Specifying default files in Apache 2.0.30 and above</h3>
-    <p>On versions 2.0.30 and above of the Apache server you can specify a default file quite cleanly using the <span class="kw"><a class="print" href="http://httpd.apache.org/docs-2.0/mod/mod_negotiation.html#forcelanguagepriority">ForceLanguagePriority</a></span> and <span class="kw"><a class="print" href="http://httpd.apache.org/docs-2.0/mod/mod_negotiation.html#languagepriority">LanguagePriority</a></span> directives (follow the links for
+    <p>On versions 2.0.30 and above of the Apache server you can specify a default file quite cleanly using the <span class="kw"><a class="print" href="https://httpd.apache.org/docs/2.4/mod/mod_negotiation.html#ForceLanguagePriority">ForceLanguagePriority</a></span> and <span class="kw"><a class="print" href="https://httpd.apache.org/docs/2.4/mod/mod_negotiation.html#languagepriority">LanguagePriority</a></span> directives (follow the links for
       detailed descriptions of how these directives work).</p>
     <p>Given our example above, we could set the default to be English using the following two lines:</p>
     <blockquote>
@@ -217,7 +217,7 @@ f.additionalLinks = ''
       <p><a href="http://httpd.apache.org/docs/content-negotiation.html">Apache documentation on Content Negotiation, version 1</a></p>
     </li>
     <li>
-      <p><a href="http://httpd.apache.org/docs-2.0/content-negotiation.html">Apache documentation on Content Negotiation, version 2</a></p>
+      <p><a href="https://httpd.apache.org/docs/2.4/content-negotiation.html">Apache documentation on Content Negotiation, version 2.4</a></p>
     </li>
     <li>
       <p>Related links, <cite>Setting up a server</cite></p>

--- a/questions/qa-apache-lang-neg.ru.html
+++ b/questions/qa-apache-lang-neg.ru.html
@@ -20,7 +20,7 @@ f.status = 'published'  // should be one of draft, review, published, notreviewe
 f.path = '../' // what you need to prepend to a URL to get to the /International directory 
 
 // AUTHORS AND TRANSLATORS should fill in these assignments:
-f.thisVersion = { date:'2016-03-03', time:'13:08'} // date and time of latest edits to this document/translation
+f.thisVersion = { date:'2025-05-22', time:'13:08'} // date and time of latest edits to this document/translation
 f.contributors = '' // people providing useful contributions or feedback during review or at other times
 // also make sure that the lang attribute on the html tag is correct!
 f.sources = '' // describes sources of information
@@ -134,7 +134,7 @@ f.additionalLinks = ''
 
   <section id="directives">
 <h3>Директивы сервера</h3>
-    <p>Вы обычно используете директиву <span class="kw"><a class="print" href="http://httpd.apache.org/docs-2.0/mod/mod_mime.html#addlanguage">AddLanguage</a></span>, чтобы
+    <p>Вы обычно используете директиву <span class="kw"><a class="print" href="https://httpd.apache.org/docs/2.4/mod/mod_mime.html#addlanguage">AddLanguage</a></span>, чтобы
       указать, какие расширения указаны для определенного языка контента в входном HTTP.</p>
     <p>Например, следующая директива направляет HTTP запрос контента, что написанный на Французском языке на расширение .fr: </p>
     <blockquote>
@@ -161,7 +161,7 @@ f.additionalLinks = ''
 
   <section id="specdef2">
 <h3>Указание файлов по умолчанию на Apache 2.0.30 и выше </h3>
-    <p>В версиях 2.0.30 и выше на сервере Apache используя директивы <span class="kw"><a class="print" href="http://httpd.apache.org/docs-2.0/mod/mod_negotiation.html#forcelanguagepriority">ForceLanguagePriority</a></span> и <span class="kw"><a class="print" href="http://httpd.apache.org/docs-2.0/mod/mod_negotiation.html#languagepriority">LanguagePriority</a></span> вы довольно четко можете указать файл по умолчанию (для получения детального описания
+    <p>В версиях 2.0.30 и выше на сервере Apache используя директивы <span class="kw"><a class="print" href="https://httpd.apache.org/docs/2.4/mod/mod_negotiation.html#ForceLanguagePriority">ForceLanguagePriority</a></span> и <span class="kw"><a class="print" href="https://httpd.apache.org/docs/2.4/mod/mod_negotiation.html#languagepriority">LanguagePriority</a></span> вы довольно четко можете указать файл по умолчанию (для получения детального описания
       работы этих директив пройдите по ссылке).</p>
     <p>Для нашего примера, мы могли бы установить Английский язык по умолчанию, используя следующие две строки:</p>
     <blockquote>
@@ -217,7 +217,7 @@ f.additionalLinks = ''
       <p><a href="http://httpd.apache.org/docs/content-negotiation.html">Документация Apache о Согласовании Контента, 1-я версия</a> </p>
     </li>
     <li>
-      <p><a href="http://httpd.apache.org/docs-2.0/content-negotiation.html">Документация Apache о Согласовании Контента, 2-я версия</a> </p>
+      <p><a href="https://httpd.apache.org/docs/2.4/content-negotiation.html">Документация Apache о Согласовании Контента, 2-я версия</a> </p>
     </li>
     <li>
       <p>Ссылки по теме, <cite>Настройка сервера</cite></p>

--- a/questions/qa-apache-lang-neg.uk.html
+++ b/questions/qa-apache-lang-neg.uk.html
@@ -20,7 +20,7 @@ f.status = 'published'  // should be one of draft, review, published, notreviewe
 f.path = '../' // what you need to prepend to a URL to get to the /International directory 
 
 // AUTHORS AND TRANSLATORS should fill in these assignments:
-f.thisVersion = { date:'2016-03-03', time:'13:08'} // date and time of latest edits to this document/translation
+f.thisVersion = { date:'2025-05-22', time:'13:08'} // date and time of latest edits to this document/translation
 f.contributors = '' // people providing useful contributions or feedback during review or at other times
 // also make sure that the lang attribute on the html tag is correct!
 f.sources = '' // describes sources of information
@@ -135,7 +135,7 @@ f.additionalLinks = ''
 
   <section id="directives">
 <h3>Директиви сервера</h3>
-    <p>Ви зазвичай використовуєте директиву <span class="kw"><a class="print" href="http://httpd.apache.org/docs-2.0/mod/mod_mime.html#addlanguage">AddLanguage</a></span>, щоб
+    <p>Ви зазвичай використовуєте директиву <span class="kw"><a class="print" href="https://httpd.apache.org/docs/2.4/mod/mod_mime.html#addlanguage">AddLanguage</a></span>, щоб
       вказати, які розширення зазначені для певної мови контенту в вхідному HTTP.</p>
     <p>Наприклад, наступна директива спрямовує HTTP запит контенту, що написаний Французькою мовою на розширення .fr: </p>
     <blockquote>
@@ -162,7 +162,7 @@ f.additionalLinks = ''
 
   <section id="specdef2">
 <h3>Вказівка ​​файлів за замовчуванням на Apache 2.0.30 і вище </h3>
-    <p>У версіях 2.0.30 і вище на сервері Apache використовуючи директиви <span class="kw"><a class="print" href="http://httpd.apache.org/docs-2.0/mod/mod_negotiation.html#forcelanguagepriority">ForceLanguagePriority</a></span> та <span class="kw"><a class="print" href="http://httpd.apache.org/docs-2.0/mod/mod_negotiation.html#languagepriority">LanguagePriority</a></span> ви досить чітко можете вказати файл за замовчуванням (для отримання детального описання 
+    <p>У версіях 2.0.30 і вище на сервері Apache використовуючи директиви <span class="kw"><a class="print" href="https://httpd.apache.org/docs/2.4/mod/mod_negotiation.html#ForceLanguagePriority">ForceLanguagePriority</a></span> та <span class="kw"><a class="print" href="https://httpd.apache.org/docs/2.4/mod/mod_negotiation.html#languagepriority">LanguagePriority</a></span> ви досить чітко можете вказати файл за замовчуванням (для отримання детального описання 
       роботи цих директив пройдіть по посиланням).</p>
     <p>Для нашого прикладу, ми могли б встановити Англійську мову за замовчуванням, використовуючи наступні два рядки:</p>
     <blockquote>
@@ -218,7 +218,7 @@ f.additionalLinks = ''
       <p><a href="http://httpd.apache.org/docs/content-negotiation.html">Документація Apache про Узгодження Контенту, 1-ша версія</a> </p>
     </li>
     <li>
-      <p><a href="http://httpd.apache.org/docs-2.0/content-negotiation.html">Документація Apache про Узгодження Контенту, 2-а версія</a> </p>
+      <p><a href="https://httpd.apache.org/docs/2.4/content-negotiation.html">Документація Apache про Узгодження Контенту, 2-а версія</a> </p>
     </li>
     <li>
       <p>Посилання по темі, <cite>Налаштування сервера</cite></p>


### PR DESCRIPTION
I checked and the content of the Apache documentation doesn't seem to have changed, but I updated them to the latest documentation links.