### PR TITLE
The name of a language is in English in the IANA Language Subtag Registry

### DIFF
--- a/questions/qa-choosing-language-tags.en.html
+++ b/questions/qa-choosing-language-tags.en.html
@@ -125,10 +125,9 @@ ins {
 </aside>
       <h3>Accessing the subtag registry</h3>
       <p>All the subtags you will need to create a language tag are found in one place, the <strong><a href="https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry">IANA Language Subtag Registry</a></strong>. The registry is a long text file, containing nearly 8,000 entries. </p>
-    <p>The first (and often only) subtag in a language tag always designates a language. It is referred to in BCP 47 as the <span class="newterm">primary language subtag</span>. We will use that term in this document to refer to the subtag that represents a language, to  more clearly make the distinction from 'language tag', which refers to the whole thing.</p>
+    <p>The first (and often only) subtag in a language tag always designates a language. It is referred to in BCP 47 as the <span class="newterm">primary language subtag</span>. We will use that term in this document to refer to the subtag that represents a language, to more clearly make the distinction from 'language tag', which refers to the whole thing.</p>
     <div class="sidenoteGroup">
-    <p>To find a primary-language subtag, search the page for the name of that language. For example, if you want to label something as French, searching
-      for '<span translate="no">French</span>' in the registry will bring you to a record that looks like this:</p>
+    <p>To find a primary-language subtag, search the page for the name of that language in English. For example, if you want to label something as French, searching for '<span translate="no">French</span>' in the registry will bring you to a record that looks like this:</p>
        <aside class="sideinfonote" style="clear:both;">
         <p class="warning">Some environments or systems may dictate choices that are different from what you would otherwise expect. For example, in Java you must use <code class="kw" translate="no">iw</code> (deprecated in BCP47) in place of <code class="kw" translate="no">he</code> (recommended in BCP47).</p>
       </aside>

--- a/questions/qa-choosing-language-tags.en.html
+++ b/questions/qa-choosing-language-tags.en.html
@@ -127,7 +127,7 @@ ins {
       <p>All the subtags you will need to create a language tag are found in one place, the <strong><a href="https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry">IANA Language Subtag Registry</a></strong>. The registry is a long text file, containing nearly 8,000 entries. </p>
     <p>The first (and often only) subtag in a language tag always designates a language. It is referred to in BCP 47 as the <span class="newterm">primary language subtag</span>. We will use that term in this document to refer to the subtag that represents a language, to more clearly make the distinction from 'language tag', which refers to the whole thing.</p>
     <div class="sidenoteGroup">
-    <p>To find a primary-language subtag, search the page for the name of that language in English. For example, if you want to label something as French, searching for '<span translate="no">French</span>' in the registry will bring you to a record that looks like this:</p>
+    <p>To find a primary language subtag, search the registry for the name of that language in English. For example, if you want to label something as French, searching for '<span translate="no">French</span>' in the registry will bring you to a record that looks like this:</p>
        <aside class="sideinfonote" style="clear:both;">
         <p class="warning">Some environments or systems may dictate choices that are different from what you would otherwise expect. For example, in Java you must use <code class="kw" translate="no">iw</code> (deprecated in BCP47) in place of <code class="kw" translate="no">he</code> (recommended in BCP47).</p>
       </aside>


### PR DESCRIPTION
Fix #514.

I'll update the translations if this is approved.