### PR TITLE
Add a copy button to code blocks

### DIFF
--- a/javascript/boilerplate-text/boilerplate-ar.js
+++ b/javascript/boilerplate-text/boilerplate-ar.js
@@ -151,6 +151,9 @@ s.quickanswer = "جواب سريع" // heading
 s.longeranswer = "تفاصيل" // heading that follows 'Quick answer'
 s.additionalinfo = "معلومات إضافية" // heading that sometimes follows 'Details'
 
+// copy button for code blocks
+s.copy = "Copy"
+s.copied = "Copied!"
 
 // obsolete in most recent articles — used to be in bottom right box
 s.subscribeToRSS = "الإنضمام إلى خدمة RSS."  

--- a/javascript/boilerplate-text/boilerplate-bg.js
+++ b/javascript/boilerplate-text/boilerplate-bg.js
@@ -151,6 +151,9 @@ s.quickanswer = "Бърз отговор" // heading
 s.longeranswer = "Детайли" // heading that follows 'Quick answer'
 s.additionalinfo = "Допълнителна информация" // heading that sometimes follows 'Details'
 
+// copy button for code blocks
+s.copy = "Copy"
+s.copied = "Copied!"
 
 // obsolete in most recent articles — used to be in bottom right box
 s.subscribeToRSS = "Абонирай се за RSS фиид."  

--- a/javascript/boilerplate-text/boilerplate-de.js
+++ b/javascript/boilerplate-text/boilerplate-de.js
@@ -151,6 +151,9 @@ s.quickanswer = "Kurze Antwort" // heading
 s.longeranswer = "Details" // heading that follows 'Quick answer'
 s.additionalinfo = "Weitere Informationen" // heading that sometimes follows 'Details'
 
+// copy button for code blocks
+s.copy = "Copy"
+s.copied = "Copied!"
 
 // obsolete in most recent articles — used to be in bottom right box
 s.subscribeToRSS = "Abonnieren Sie unseren RSS-Feed."  

--- a/javascript/boilerplate-text/boilerplate-el.js
+++ b/javascript/boilerplate-text/boilerplate-el.js
@@ -151,6 +151,9 @@ s.quickanswer = "Quick answer" // heading
 s.longeranswer = "Details" // heading that follows 'Quick answer'
 s.additionalinfo = "Additional information" // heading that sometimes follows 'Details'
 
+// copy button for code blocks
+s.copy = "Copy"
+s.copied = "Copied!"
 
 // obsolete in most recent articles — used to be in bottom right box
 s.subscribeToRSS = "Εγγραφή σε Τροφοδότη Ειδήσεων RSS."  

--- a/javascript/boilerplate-text/boilerplate-en.js
+++ b/javascript/boilerplate-text/boilerplate-en.js
@@ -149,6 +149,9 @@ s.quickanswer = "Quick answer" // heading
 s.longeranswer = "Details" // heading that follows 'Quick answer'
 s.additionalinfo = "Additional information" // heading that sometimes follows 'Details'
 
+// copy button for code blocks
+s.copy = "Copy"
+s.copied = "Copied!"
 
 // obsolete in most recent articles — used to be in bottom right box
 s.subscribeToRSS = "Subscribe to an RSS feed."  

--- a/javascript/boilerplate-text/boilerplate-es.js
+++ b/javascript/boilerplate-text/boilerplate-es.js
@@ -151,6 +151,10 @@ s.quickanswer = "Respuesta rápida" // heading
 s.longeranswer = "Respuesta extensa" // heading that follows 'Quick answer'
 s.additionalinfo = "Información adicional" // heading that sometimes follows 'Details'
 
+// copy button for code blocks
+s.copy = "Copy"
+s.copied = "Copied!"
+
 
 // obsolete in most recent articles — used to be in bottom right box
 s.subscribeToRSS = "Suscripción a feed RSS."  

--- a/javascript/boilerplate-text/boilerplate-fr.js
+++ b/javascript/boilerplate-text/boilerplate-fr.js
@@ -151,6 +151,10 @@ s.quickanswer = "Réponse courte" // heading
 s.longeranswer = "Détails" // heading that follows 'Quick answer'
 s.additionalinfo = "Information complémentaire" // heading that sometimes follows 'Details'
 
+// copy button for code blocks
+s.copy = "Copy"
+s.copied = "Copied!"
+
 
 // obsolete in most recent articles — used to be in bottom right box
 s.subscribeToRSS = "Abonnez-vous au flux RSS."  

--- a/javascript/boilerplate-text/boilerplate-gl.js
+++ b/javascript/boilerplate-text/boilerplate-gl.js
@@ -151,6 +151,9 @@ s.quickanswer = "Resposta rápida" // heading
 s.longeranswer = "Detalles" // heading that follows 'Quick answer'
 s.additionalinfo = "Información adicional" // heading that sometimes follows 'Details'
 
+// copy button for code blocks
+s.copy = "Copy"
+s.copied = "Copied!"
 
 // obsolete in most recent articles — used to be in bottom right box
 s.subscribeToRSS = "Suscríbete ó RSS."  

--- a/javascript/boilerplate-text/boilerplate-he.js
+++ b/javascript/boilerplate-text/boilerplate-he.js
@@ -151,6 +151,9 @@ s.quickanswer = "Quick answer" // heading
 s.longeranswer = "Details" // heading that follows 'Quick answer'
 s.additionalinfo = "Additional information" // heading that sometimes follows 'Details'
 
+// copy button for code blocks
+s.copy = "Copy"
+s.copied = "Copied!"
 
 // obsolete in most recent articles — used to be in bottom right box
 s.subscribeToRSS = "הירשם להזנת RSS."  

--- a/javascript/boilerplate-text/boilerplate-hi.js
+++ b/javascript/boilerplate-text/boilerplate-hi.js
@@ -151,6 +151,9 @@ s.quickanswer = "त्वरित उत्तर" // heading
 s.longeranswer = "विवरण" // heading that follows 'Quick answer'
 s.additionalinfo = "अतिरिक्त जानकारी" // heading that sometimes follows 'Details'
 
+// copy button for code blocks
+s.copy = "Copy"
+s.copied = "Copied!"
 
 // obsolete in most recent articles — used to be in bottom right box
 s.subscribeToRSS = "एक आरएसएस फ़ीड की सदस्यता लें।"  

--- a/javascript/boilerplate-text/boilerplate-hu.js
+++ b/javascript/boilerplate-text/boilerplate-hu.js
@@ -151,6 +151,9 @@ s.quickanswer = "Gyors válasz" // heading
 s.longeranswer = "Részletek" // heading that follows 'Quick answer'
 s.additionalinfo = "További információ" // heading that sometimes follows 'Details'
 
+// copy button for code blocks
+s.copy = "Copy"
+s.copied = "Copied!"
 
 // obsolete in most recent articles — used to be in bottom right box
 s.subscribeToRSS = "Feliratkozás az RSS csatornára."  

--- a/javascript/boilerplate-text/boilerplate-it.js
+++ b/javascript/boilerplate-text/boilerplate-it.js
@@ -151,6 +151,9 @@ s.quickanswer = "Risposta rapida" // heading
 s.longeranswer = "Dettagli" // heading that follows 'Quick answer'
 s.additionalinfo = "Informazioni complementari" // heading that sometimes follows 'Details'
 
+// copy button for code blocks
+s.copy = "Copy"
+s.copied = "Copied!"
 
 // obsolete in most recent articles — used to be in bottom right box
 s.subscribeToRSS = "Sottoscrivi il feed RSS."  

--- a/javascript/boilerplate-text/boilerplate-ja.js
+++ b/javascript/boilerplate-text/boilerplate-ja.js
@@ -151,6 +151,9 @@ s.quickanswer = "端的な回答" // heading
 s.longeranswer = "詳細な回答" // heading that follows 'Quick answer'
 s.additionalinfo = "補足情報" // heading that sometimes follows 'Details'
 
+// copy button for code blocks
+s.copy = "Copy"
+s.copied = "Copied!"
 
 // obsolete in most recent articles — used to be in bottom right box
 s.subscribeToRSS = "RSSフィードを購読する"  

--- a/javascript/boilerplate-text/boilerplate-ko.js
+++ b/javascript/boilerplate-text/boilerplate-ko.js
@@ -151,6 +151,9 @@ s.quickanswer = "undefined" // heading
 s.longeranswer = "Details" // heading that follows 'Quick answer'
 s.additionalinfo = "Additional information" // heading that sometimes follows 'Details'
 
+// copy button for code blocks
+s.copy = "Copy"
+s.copied = "Copied!"
 
 // obsolete in most recent articles — used to be in bottom right box
 s.subscribeToRSS = "RSS feed에 가입합니다."  

--- a/javascript/boilerplate-text/boilerplate-nl.js
+++ b/javascript/boilerplate-text/boilerplate-nl.js
@@ -151,6 +151,9 @@ s.quickanswer = "Kort antwoord" // heading
 s.longeranswer = "Details" // heading that follows 'Quick answer'
 s.additionalinfo = "Aanvullende informatie" // heading that sometimes follows 'Details'
 
+// copy button for code blocks
+s.copy = "Copy"
+s.copied = "Copied!"
 
 // obsolete in most recent articles — used to be in bottom right box
 s.subscribeToRSS = "Abonneer u op een nieuwsfeed."

--- a/javascript/boilerplate-text/boilerplate-pes.js
+++ b/javascript/boilerplate-text/boilerplate-pes.js
@@ -151,6 +151,9 @@ s.quickanswer = "پاسخ سریع" // heading
 s.longeranswer = "جزئیات" // heading that follows 'Quick answer'
 s.additionalinfo = "اطلاعات اضافی" // heading that sometimes follows 'Details'
 
+// copy button for code blocks
+s.copy = "Copy"
+s.copied = "Copied!"
 
 // obsolete in most recent articles — used to be in bottom right box
 s.subscribeToRSS = "اشتراک در خوراک RSS."  

--- a/javascript/boilerplate-text/boilerplate-pl.js
+++ b/javascript/boilerplate-text/boilerplate-pl.js
@@ -151,6 +151,9 @@ s.quickanswer = "Krótka odpowiedź" // heading
 s.longeranswer = "Szczegóły" // heading that follows 'Quick answer'
 s.additionalinfo = "Dodatkowe informacje" // heading that sometimes follows 'Details'
 
+// copy button for code blocks
+s.copy = "Copy"
+s.copied = "Copied!"
 
 // obsolete in most recent articles — used to be in bottom right box
 s.subscribeToRSS = "Prenumeruj kanał RSS."  

--- a/javascript/boilerplate-text/boilerplate-pt-br.js
+++ b/javascript/boilerplate-text/boilerplate-pt-br.js
@@ -151,6 +151,9 @@ s.quickanswer = "Resposta resumida" // heading
 s.longeranswer = "Detalhes" // heading that follows 'Quick answer'
 s.additionalinfo = "Informações adicionais" // heading that sometimes follows 'Details'
 
+// copy button for code blocks
+s.copy = "Copy"
+s.copied = "Copied!"
 
 // obsolete in most recent articles — used to be in bottom right box
 s.subscribeToRSS = "Subscreva uma alimentação RSS."  

--- a/javascript/boilerplate-text/boilerplate-pt.js
+++ b/javascript/boilerplate-text/boilerplate-pt.js
@@ -151,6 +151,9 @@ s.quickanswer = "Quick answer" // heading
 s.longeranswer = "Longer answer" // heading that follows 'Quick answer'
 s.additionalinfo = "Additional information" // heading that sometimes follows 'Details'
 
+// copy button for code blocks
+s.copy = "Copy"
+s.copied = "Copied!"
 
 // obsolete in most recent articles — used to be in bottom right box
 s.subscribeToRSS = "Subscreva uma alimentação RSS."  

--- a/javascript/boilerplate-text/boilerplate-ro.js
+++ b/javascript/boilerplate-text/boilerplate-ro.js
@@ -151,6 +151,9 @@ s.quickanswer = "Quick answer" // heading
 s.longeranswer = "Longer answer" // heading that follows 'Quick answer'
 s.additionalinfo = "Additional information" // heading that sometimes follows 'Details'
 
+// copy button for code blocks
+s.copy = "Copy"
+s.copied = "Copied!"
 
 // obsolete in most recent articles — used to be in bottom right box
 s.subscribeToRSS = "Abonează-te la RSS feed."  

--- a/javascript/boilerplate-text/boilerplate-ru.js
+++ b/javascript/boilerplate-text/boilerplate-ru.js
@@ -151,6 +151,9 @@ s.quickanswer = "Быстрый ответ" // heading
 s.longeranswer = "Подробный ответ" // heading that follows 'Quick answer'
 s.additionalinfo = "Дополнительная информация" // heading that sometimes follows 'Details'
 
+// copy button for code blocks
+s.copy = "Copy"
+s.copied = "Copied!"
 
 // obsolete in most recent articles — used to be in bottom right box
 s.subscribeToRSS = "Подпишитесь на ленту новостей RSS."  

--- a/javascript/boilerplate-text/boilerplate-sv.js
+++ b/javascript/boilerplate-text/boilerplate-sv.js
@@ -151,6 +151,9 @@ s.quickanswer = "Snabbt svar" // heading
 s.longeranswer = "Detaljer" // heading that follows 'Quick answer'
 s.additionalinfo = "Ytterligare information" // heading that sometimes follows 'Details'
 
+// copy button for code blocks
+s.copy = "Copy"
+s.copied = "Copied!"
 
 // obsolete in most recent articles — used to be in bottom right box
 s.subscribeToRSS = "Prenumerera på en RSS-kanal."  

--- a/javascript/boilerplate-text/boilerplate-th.js
+++ b/javascript/boilerplate-text/boilerplate-th.js
@@ -151,6 +151,9 @@ s.quickanswer = "Quick answer" // heading
 s.longeranswer = "Longer answer" // heading that follows 'Quick answer'
 s.additionalinfo = "Additional information" // heading that sometimes follows 'Details'
 
+// copy button for code blocks
+s.copy = "Copy"
+s.copied = "Copied!"
 
 // obsolete in most recent articles — used to be in bottom right box
 s.subscribeToRSS = "ลงทะเบียนรับข่าวสาร RSS ฟีด"  

--- a/javascript/boilerplate-text/boilerplate-tr.js
+++ b/javascript/boilerplate-text/boilerplate-tr.js
@@ -151,6 +151,9 @@ s.quickanswer = "Quick answer" // heading
 s.longeranswer = "Details" // heading that follows 'Quick answer'
 s.additionalinfo = "Additional information" // heading that sometimes follows 'Details'
 
+// copy button for code blocks
+s.copy = "Copy"
+s.copied = "Copied!"
 
 // obsolete in most recent articles — used to be in bottom right box
 s.subscribeToRSS = "Bir RSS akışına abone olun."  

--- a/javascript/boilerplate-text/boilerplate-uk.js
+++ b/javascript/boilerplate-text/boilerplate-uk.js
@@ -151,6 +151,10 @@ s.quickanswer = "Швидка відповідь" // heading
 s.longeranswer = "Детальна відповідь" // heading that follows 'Quick answer'
 s.additionalinfo = "Additional information" // heading that sometimes follows 'Details'
 
+// copy button for code blocks
+s.copy = "Copy"
+s.copied = "Copied!"
+
 
 // obsolete in most recent articles — used to be in bottom right box
 s.subscribeToRSS = "Підписатися на RSS джерело."  

--- a/javascript/boilerplate-text/boilerplate-vi.js
+++ b/javascript/boilerplate-text/boilerplate-vi.js
@@ -151,6 +151,9 @@ s.quickanswer = "Quick answer" // heading
 s.longeranswer = "Details" // heading that follows 'Quick answer'
 s.additionalinfo = "Additional information" // heading that sometimes follows 'Details'
 
+// copy button for code blocks
+s.copy = "Copy"
+s.copied = "Copied!"
 
 // obsolete in most recent articles — used to be in bottom right box
 s.subscribeToRSS = "Đăng ký đọc tin RSS."  

--- a/javascript/boilerplate-text/boilerplate-zh-hans.js
+++ b/javascript/boilerplate-text/boilerplate-zh-hans.js
@@ -151,6 +151,9 @@ s.quickanswer = "简约回复" // heading
 s.longeranswer = "详情" // heading that follows 'Quick answer'
 s.additionalinfo = "更多信息" // heading that sometimes follows 'Details'
 
+// copy button for code blocks
+s.copy = "复制"
+s.copied = "已复制！"
 
 // obsolete in most recent articles — used to be in bottom right box
 s.subscribeToRSS = "订阅 RSS 提要"  

--- a/javascript/boilerplate-text/boilerplate-zh-hant.js
+++ b/javascript/boilerplate-text/boilerplate-zh-hant.js
@@ -152,6 +152,9 @@ s.quickanswer = "快速回答" // heading
 s.longeranswer = "細節" // heading that follows 'Quick answer'
 s.additionalinfo = "附加資訊" // heading that sometimes follows 'Details'
 
+// copy button for code blocks
+s.copy = "Copy"
+s.copied = "Copied!"
 
 // obsolete in most recent articles — used to be in bottom right box
 s.subscribeToRSS = "訂閲 RSS feed."  

--- a/javascript/boilerplate-text/make_boilerplate.html
+++ b/javascript/boilerplate-text/make_boilerplate.html
@@ -205,6 +205,9 @@ s.quickanswer = "${ s.quickanswer }" // heading
 s.longeranswer = "${ s.longeranswer }" // heading that follows 'Quick answer'
 s.additionalinfo = "${ s.additionalinfo }" // heading that sometimes follows 'Details'
 
+// copy button for code blocks
+s.copy = "${ s.copy }"
+s.copied = "${ s.copied }"
 
 // obsolete in most recent articles — used to be in bottom right box
 s.subscribeToRSS = "${ s.subscribeToRSS }"  

--- a/javascript/doc-structure/article-2022.js
+++ b/javascript/doc-structure/article-2022.js
@@ -309,3 +309,31 @@ function getURLs () {
 	if (document.querySelector('#endlinks')) document.querySelector('#endlinks').parentNode.appendChild(container)
 	
 	}
+
+// Simple copy button for code blocks
+document.addEventListener('DOMContentLoaded', function() {
+    const codeBlocks = document.querySelectorAll('pre code');
+
+    codeBlocks.forEach(function(code) {
+        const pre = code.parentElement;
+        const copyBtn = document.createElement('button');
+        copyBtn.className = 'copy-btn';
+        copyBtn.textContent = s.copy;
+
+        copyBtn.addEventListener('click', async function() {
+            const text = code.textContent;
+
+            try {
+                await navigator.clipboard.writeText(text);
+                copyBtn.textContent = s.copied;
+                setTimeout(function() {
+                    copyBtn.textContent = s.copy;
+                }, 2000);
+            } catch (err) {
+                console.error('Failed to copy text: ', err);
+            }
+        });
+
+        pre.appendChild(copyBtn);
+    });
+});

--- a/style/article-2022.css
+++ b/style/article-2022.css
@@ -1121,6 +1121,33 @@ em:lang(pes) {
     }
 
 
+/* Simple copy button for code blocks */
+pre {
+    position: relative;
+}
+
+.copy-btn {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    background: #f8f9fa;
+    border: 1px solid #dee2e6;
+    border-radius: 4px;
+    padding: 4px 8px;
+    font-size: 12px;
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity 0.2s;
+}
+
+pre:hover .copy-btn {
+    opacity: 1;
+}
+
+.copy-btn:hover {
+    background: #e9ecef;
+}
+
 /* ************** specials ********************* */
 
 .dontuse { 


### PR DESCRIPTION
I often copy the code in the articles so I added a copy button.

Test here: https://deploy-preview-737--i18n-drafts.netlify.app/questions/qa-html-dir.en.html#basicmarkup