### PR TITLE
Not adding lang for targetLang === en

### DIFF
--- a/javascript/doc-structure/sitepage-2022.js
+++ b/javascript/doc-structure/sitepage-2022.js
@@ -99,7 +99,7 @@ function stickyConneg (filename, cLang, targetLang) {
 		var path = ";path=/"
 		document.cookie = 'w3ci18nlang='+targetLang+expires+path
 		}
-	if (targetLang === 'en') targetLang = '.en.html'
+	if (targetLang === 'en') targetLang = '.html'
 	else targetLang = '.'+targetLang+'.html'
 	document.location.assign(filename+targetLang)
 	}


### PR DESCRIPTION
closes #743 
I suppose this should be somekind of typo, since targetLang === 'en' is specifically chosen but building the same output.